### PR TITLE
Fix ensemble PMM job dependency to require successful completion

### DIFF
--- a/submit_all.sh
+++ b/submit_all.sh
@@ -95,7 +95,7 @@ fi
 # ensemble PMM
 if [ $N_ENSEMBLES -ge 2 ]; then
     atparse < $PACKAGEROOT/jobs/job-compute-pmm.sh > $DATAROOT/logs/job-compute-pmm.sh
-    jobid7=$(submit_with_check sbatch --dependency=after:$jobid5 --parsable $DATAROOT/logs/job-compute-pmm.sh)
+    jobid7=$(submit_with_check sbatch --dependency=afterok:$jobid5 --parsable $DATAROOT/logs/job-compute-pmm.sh)
     echo "Submitted job: $jobid7"
 
     if [ "$RUNPLOT" == "YES" ]; then


### PR DESCRIPTION
This changes the Slurm dependency for the ensemble PMM job from `after` to `afterok` in submit_all.sh. With `after`, the PMM job runs after the ensemble inference job terminates regardless of exit status. With `afterok`, it only runs after successful completion.