### PR TITLE
Add PyTorch inference port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+scripts/

--- a/src/fcst.py
+++ b/src/fcst.py
@@ -14,7 +14,6 @@ import logging
 import os
 import sys
 import time
-from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
@@ -22,62 +21,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import numpy as np
 import tensorflow as tf
+import xarray as xr
 import pandas as pd
+from skimage.exposure import match_histograms
 
-_PROFILE_TRUE = {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
-_BENCH_SKIP_OUTPUT = os.environ.get("HRRRCAST_BENCH_SKIP_OUTPUT", "") in _PROFILE_TRUE
-
-try:
-    import xarray as xr
-except ImportError:
-    if not _BENCH_SKIP_OUTPUT:
-        raise
-
-    class _ArrayWithValues:
-        def __init__(self, values):
-            self.values = values
-
-    class _H5NormDataset:
-        def __init__(self, path):
-            import h5py
-
-            self._h5 = h5py.File(path, "r")
-            self.variables = set(self._h5.keys())
-
-        def __getitem__(self, key):
-            return _ArrayWithValues(np.asarray(self._h5[key]))
-
-        def close(self):
-            self._h5.close()
-
-    class _XarrayShim:
-        Dataset = object
-        DataArray = object
-
-        @staticmethod
-        def open_dataset(path, *args, **kwargs):
-            return _H5NormDataset(path)
-
-    xr = _XarrayShim()
-
-try:
-    from skimage.exposure import match_histograms
-except ImportError:
-    if not _BENCH_SKIP_OUTPUT:
-        raise
-
-    def match_histograms(image, reference, channel_axis=None):
-        return image
-
-try:
-    from nc2grib import Netcdf2Grib
-except ImportError:
-    if not _BENCH_SKIP_OUTPUT:
-        raise
-
-    class Netcdf2Grib:
-        def save_grib2(self, *args, **kwargs):
-            raise RuntimeError("Netcdf2Grib is unavailable in HRRRCAST_BENCH_SKIP_OUTPUT mode")
+from nc2grib import Netcdf2Grib
 
 # Import custom modules (assuming they exist)
 try:
@@ -102,100 +50,9 @@ from transform import (
 import utils
 from utils import setup_logging
 from diagnostics import compute_diagnostics
-try:
-    from compute_pmm import compute_PMM
-except ImportError:
-    if not _BENCH_SKIP_OUTPUT:
-        raise
-
-    def compute_PMM(*args, **kwargs):
-        raise RuntimeError("compute_PMM is unavailable in HRRRCAST_BENCH_SKIP_OUTPUT mode")
+from compute_pmm import compute_PMM
 
 logger = None
-
-
-def _profile_env(name: str) -> bool:
-    return os.environ.get(name, "") in _PROFILE_TRUE
-
-
-def _profile_timing_enabled() -> bool:
-    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_PROFILE_TIMING")
-
-
-def _profile_nvtx_enabled() -> bool:
-    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_NVTX")
-
-
-def _profile_sync_enabled() -> bool:
-    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_SYNC_TIMING")
-
-
-def _profile_log(message: str, *args) -> None:
-    if logger is not None:
-        logger.info(message, *args)
-    else:
-        logging.info(message, *args)
-
-
-def _tf_sync_if_enabled() -> None:
-    if not _profile_sync_enabled():
-        return
-    async_wait = getattr(getattr(tf, "experimental", None), "async_wait", None)
-    if async_wait is not None:
-        async_wait()
-
-
-def _nvtx_push(name: str) -> bool:
-    if not _profile_nvtx_enabled():
-        return False
-    try:
-        import nvtx  # type: ignore
-    except Exception:
-        return False
-    if hasattr(nvtx, "push_range"):
-        nvtx.push_range(name)
-        return True
-    if hasattr(nvtx, "range_push"):
-        nvtx.range_push(name)
-        return True
-    return False
-
-
-def _nvtx_pop() -> None:
-    try:
-        import nvtx  # type: ignore
-    except Exception:
-        return
-    if hasattr(nvtx, "pop_range"):
-        nvtx.pop_range()
-    elif hasattr(nvtx, "range_pop"):
-        nvtx.range_pop()
-
-
-@contextmanager
-def profile_region(name: str, extra: str = "", detail: bool = False):
-    """Optional source-level timing/NVTX instrumentation."""
-    if detail and not _profile_env("HRRRCAST_PROFILE_DETAIL"):
-        yield
-        return
-
-    do_timing = _profile_timing_enabled()
-    if not (do_timing or _profile_nvtx_enabled() or _profile_sync_enabled()):
-        yield
-        return
-
-    _tf_sync_if_enabled()
-    pushed = _nvtx_push(name)
-    t0 = time.perf_counter()
-    try:
-        yield
-    finally:
-        _tf_sync_if_enabled()
-        elapsed = time.perf_counter() - t0
-        if pushed:
-            _nvtx_pop()
-        if do_timing:
-            _profile_log("BENCH phase=%s%s seconds=%.6f", name, extra, elapsed)
 
 
 def make_noise(
@@ -234,35 +91,34 @@ class PreprocessedDataLoader:
         """Load preprocessed data from file."""
         if not os.path.exists(self.preprocessed_file):
             raise FileNotFoundError(f"Preprocessed data file not found: {self.preprocessed_file}")
-
-        with profile_region("tf.data_load", extra=f" file={Path(self.preprocessed_file).name}"):
-            try:
-                logger.info(f"Loading preprocessed data from {self.preprocessed_file}")
-                self.data = np.load(self.preprocessed_file)
-                
-                # Extract metadata
-                self.metadata = {
-                    'init_year': str(self.data['init_year']),
-                    'init_month': str(self.data['init_month']),
-                    'init_day': str(self.data['init_day']),
-                    'init_hh': str(self.data['init_hh']),
-                    'init_datetime': str(self.data['init_datetime']),
-                    'pl_vars': self.data['pl_vars'].tolist(),
-                    'sfc_vars': self.data['sfc_vars'].tolist(),
-                    'levels': self.data['levels'].tolist(),
-                    'grid_height': int(self.data['grid_height']),
-                    'grid_width': int(self.data['grid_width']),
-                    'downsample_factor': int(self.data['downsample_factor']),
-                    'norm_file': str(self.data['norm_file'])
-                }
-                
-                logger.info("Preprocessed data loaded successfully")
-                logger.info(f"Model input shape: {self.data['model_input'].shape}")
-                logger.info(f"Initialization time: {self.metadata['init_datetime']}")
-                
-            except Exception as e:
-                logger.error(f"Error loading preprocessed data: {e}")
-                raise
+        
+        try:
+            logger.info(f"Loading preprocessed data from {self.preprocessed_file}")
+            self.data = np.load(self.preprocessed_file)
+            
+            # Extract metadata
+            self.metadata = {
+                'init_year': str(self.data['init_year']),
+                'init_month': str(self.data['init_month']),
+                'init_day': str(self.data['init_day']),
+                'init_hh': str(self.data['init_hh']),
+                'init_datetime': str(self.data['init_datetime']),
+                'pl_vars': self.data['pl_vars'].tolist(),
+                'sfc_vars': self.data['sfc_vars'].tolist(),
+                'levels': self.data['levels'].tolist(),
+                'grid_height': int(self.data['grid_height']),
+                'grid_width': int(self.data['grid_width']),
+                'downsample_factor': int(self.data['downsample_factor']),
+                'norm_file': str(self.data['norm_file'])
+            }
+            
+            logger.info("Preprocessed data loaded successfully")
+            logger.info(f"Model input shape: {self.data['model_input'].shape}")
+            logger.info(f"Initialization time: {self.metadata['init_datetime']}")
+            
+        except Exception as e:
+            logger.error(f"Error loading preprocessed data: {e}")
+            raise
     
     def get_model_input(self) -> np.ndarray:
         """Get the model input array."""
@@ -283,10 +139,8 @@ class ForecastModel:
     def __init__(self, model_path: str):
         self.model_path = model_path
         self.model = None
-        with profile_region("tf.tf_setup"):
-            self._setup_tf_environment()
-        with profile_region("tf.model_load"):
-            self._load_model()
+        self._setup_tf_environment()
+        self._load_model()
 
     def _setup_tf_environment(self) -> None:
         """ 
@@ -334,8 +188,7 @@ class ForecastModel:
             raise RuntimeError("Model not loaded")
         
         try:
-            with profile_region("tf.model_forward", detail=True):
-                return self.model(input_data, training=False)
+            return self.model(input_data, training=False)
         except Exception as e:
             logger.error(f"Error during model prediction: {e}")
             raise
@@ -407,17 +260,16 @@ class WeatherForecaster:
 
         # Load normalization file and construct per-channel mean/std vectors consistent with preprocessing
         norm_file = self.metadata["norm_file"]
-        with profile_region("tf.norm_stats_load"):
-            try:
-                ds_norm = xr.open_dataset(norm_file)
-                self._init_channel_stats(ds_norm)
-                ds_norm.close()
-                logger.info(
-                    f"Normalization file loaded and channel stats constructed: {norm_file}"
-                )
-            except Exception as e:
-                logger.error(f"Error loading/processing normalization file: {e}")
-                raise
+        try:
+            ds_norm = xr.open_dataset(norm_file)
+            self._init_channel_stats(ds_norm)
+            ds_norm.close()
+            logger.info(
+                f"Normalization file loaded and channel stats constructed: {norm_file}"
+            )
+        except Exception as e:
+            logger.error(f"Error loading/processing normalization file: {e}")
+            raise
 
         # Initialize per-member base noise anchors (on-the-fly generation in predict)
         logger.info(f"Initializing member anchors for {len(self.members)} members")
@@ -749,14 +601,13 @@ class WeatherForecaster:
         """
         t0 = time.time()
 
-        with profile_region("tf.output_build", extra=f" hour={hour}"):
-            # Denormalize to physical units
-            denorm = self.denormalize(forecast_norm)
-            # Ensure shape (time=1, Ny, Nx, C)
-            if denorm.ndim == 3:
-                denorm = denorm[None, ...]
-            times = [hour]
-            ds_hour = self.create_xarray_dataset(init_datetime, times, lats, lons, denorm)
+        # Denormalize to physical units
+        denorm = self.denormalize(forecast_norm)
+        # Ensure shape (time=1, Ny, Nx, C)
+        if denorm.ndim == 3:
+            denorm = denorm[None, ...]
+        times = [hour]
+        ds_hour = self.create_xarray_dataset(init_datetime, times, lats, lons, denorm)
 
         # Inject constants if present in preprocessed NPZ (repeat across lead_time length 1)
         for cname in ["LAND", "OROG"]:
@@ -814,8 +665,7 @@ class WeatherForecaster:
         if mem_str not in {"avg", "spr"}:
             mem_str = f"m{int(member):02d}"
         nc_path = outdir / f"hrrrcast_{mem_str}_f{hour:02d}.nc"
-        with profile_region("tf.netcdf_write", extra=f" hour={hour} member={member}"):
-            ds_hour.to_netcdf(nc_path)
+        ds_hour.to_netcdf(nc_path)
 
         write_time = time.time() - t0
         logger.info(f"Wrote NetCDF in {write_time:.3f}s : {nc_path}")
@@ -856,8 +706,7 @@ class WeatherForecaster:
                 ds_hour = ds_hour.assign_coords(lead_time=("lead_time", [hour]))
             except Exception:
                 pass
-        with profile_region("tf.grib2_write", extra=f" hour={hour} member={member}"):
-            converter.save_grib2(init_datetime, ds_hour, str(grib2_path))
+        converter.save_grib2(init_datetime, ds_hour, str(grib2_path))
 
         write_time = time.time() - t0
         logger.info(f"Wrote GRIB2 in {write_time:.3f}s : {grib2_path}")
@@ -1100,9 +949,6 @@ class WeatherForecaster:
 
         def build_and_submit_hour_outputs(hour: int, data: np.ndarray, member: int) -> None:
             """Build the dataset in a worker, then submit both file writes."""
-            if _BENCH_SKIP_OUTPUT:
-                logger.debug(f"Skipping output build/write for hour {hour} member {member}")
-                return
             try:
                 ds_hour = self.build_single_hour_dataset(init_datetime, hour, lats, lons, data)
             except Exception as e:
@@ -1205,11 +1051,7 @@ class WeatherForecaster:
                 
                 # Predict next-hour fields for entire batch using hour-specific noise
                 t0 = time.time()
-                with profile_region(
-                    "tf.predict",
-                    extra=f" hour={hour} batch={batch_start//batch_size + 1} members={batch_members_list}",
-                ):
-                    y_batch = self.predict(model, X_batch, batch_members_list, hour=hour)
+                y_batch = self.predict(model, X_batch, batch_members_list, hour=hour)
                 predict_time = time.time() - t0
                 logger.info(f"Hour {hour}, batch {batch_start//batch_size + 1}: predict took {predict_time:.3f}s")
                 
@@ -1227,8 +1069,7 @@ class WeatherForecaster:
                     # state for this member
                     if hour % rollout_hour == 0:
                         state_from_hour[member] = y
-                    with profile_region("tf.output_stage", extra=f" hour={hour} member={member}"):
-                        hour_member_outputs[member] = y.numpy().copy()
+                    hour_member_outputs[member] = y.numpy().copy()
 
             # Compute PMM mean for this hour and nudge members before writing (if enabled)
             if self.use_nudging:
@@ -1248,15 +1089,14 @@ class WeatherForecaster:
         # Wait for all background work to complete. Build tasks must drain first so
         # they cannot submit into executors that are already shutting down.
         logger.info(f"Waiting for {len(build_futures)} background build operations to complete...")
-        with profile_region("tf.output_wait"):
-            for future in as_completed(build_futures):
-                try:
-                    future.result()
-                except Exception as e:
-                    logger.error(f"Background build operation failed: {e}")
-            build_executor.shutdown(wait=True)
-            nc_executor.shutdown(wait=True)
-            grib2_executor.shutdown(wait=True)
+        for future in as_completed(build_futures):
+            try:
+                future.result()
+            except Exception as e:
+                logger.error(f"Background build operation failed: {e}")
+        build_executor.shutdown(wait=True)
+        nc_executor.shutdown(wait=True)
+        grib2_executor.shutdown(wait=True)
         logger.info("All background output operations completed")
 
         logger.info("Autoregressive rollout completed")
@@ -1322,15 +1162,14 @@ class WeatherForecaster:
             logger.info(self.metadata)
 
             # Run autoregressive forecast and write per-hour outputs to disk
-            with profile_region("tf.rollout_total"):
-                self.autoregressive_rollout(
-                    model_input,
-                    self.data_loader_gfs.get_model_input(),
-                    model,
-                    lead_hours,
-                    output_dir=output_dir,
-                    init_datetime=init_datetime,
-                )
+            self.autoregressive_rollout(
+                model_input,
+                self.data_loader_gfs.get_model_input(),
+                model,
+                lead_hours,
+                output_dir=output_dir,
+                init_datetime=init_datetime,
+            )
             logger.info("Forecast completed successfully (per-hour outputs written during rollout)")
         except Exception as e:
             logger.error(f"Forecast failed: {e}")
@@ -1396,76 +1235,73 @@ def main():
             members.extend(expand_member_arg(m))
         members = sorted(set(members))  # Remove duplicates and sort
 
-        with profile_region("tf.total_process"):
-            # Load preprocessed data and model ONCE
-            init_datetime, init_year, init_month, init_day, init_hh = utils.validate_datetime(args.inittime)
-            date_str = f"{init_year}{init_month}{init_day}/{init_hh}"
-            filedate_str = f"{init_year}{init_month}{init_day}_{init_hh}"
-            hrrr_preprocessed_file = f"{args.base_dir}/{date_str}/hrrr_{filedate_str}.npz"
-            gfs_preprocessed_file = f"{args.base_dir}/{date_str}/gfs_{filedate_str}.npz"
-            data_loader_hrrr = PreprocessedDataLoader(hrrr_preprocessed_file)
-            data_loader_gfs = PreprocessedDataLoader(gfs_preprocessed_file)
-            model = ForecastModel(args.model_path)
+        # Load preprocessed data and model ONCE
+        init_datetime, init_year, init_month, init_day, init_hh = utils.validate_datetime(args.inittime)
+        date_str = f"{init_year}{init_month}{init_day}/{init_hh}"
+        filedate_str = f"{init_year}{init_month}{init_day}_{init_hh}"
+        hrrr_preprocessed_file = f"{args.base_dir}/{date_str}/hrrr_{filedate_str}.npz"
+        gfs_preprocessed_file = f"{args.base_dir}/{date_str}/gfs_{filedate_str}.npz"
+        data_loader_hrrr = PreprocessedDataLoader(hrrr_preprocessed_file)
+        data_loader_gfs = PreprocessedDataLoader(gfs_preprocessed_file)
+        model = ForecastModel(args.model_path)
 
-            # Precompute model_input ONCE
-            with profile_region("tf.tensor_prep"):
-                model_input_hrrr = data_loader_hrrr.get_model_input()
-                model_input_gfs = data_loader_gfs.get_model_input()
+        # Precompute model_input ONCE
+        model_input_hrrr = data_loader_hrrr.get_model_input()
+        model_input_gfs = data_loader_gfs.get_model_input()
 
-                pl_vars = data_loader_hrrr.metadata["pl_vars"]
-                sfc_vars = data_loader_hrrr.metadata["sfc_vars"]
-                levels = data_loader_hrrr.metadata["levels"]
-                predicted_channels = len(pl_vars) * len(levels) + len(sfc_vars)
-                gfs_channels = model_input_gfs.shape[-1]
-                static_channels = max(model_input_hrrr.shape[-1] - predicted_channels, 0)
+        pl_vars = data_loader_hrrr.metadata["pl_vars"]
+        sfc_vars = data_loader_hrrr.metadata["sfc_vars"]
+        levels = data_loader_hrrr.metadata["levels"]
+        predicted_channels = len(pl_vars) * len(levels) + len(sfc_vars)
+        gfs_channels = model_input_gfs.shape[-1]
+        static_channels = max(model_input_hrrr.shape[-1] - predicted_channels, 0)
 
-                nlat = model_input_hrrr.shape[1]
-                nlon = model_input_hrrr.shape[2]
-                date_channel = np.ones((1, nlat, nlon, 6), dtype=model_input_hrrr.dtype)
-                lead_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
-                step_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
+        nlat = model_input_hrrr.shape[1]
+        nlon = model_input_hrrr.shape[2]
+        date_channel = np.ones((1, nlat, nlon, 6), dtype=model_input_hrrr.dtype)
+        lead_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
+        step_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
 
-                if not args.no_diffusion:
-                    rand_channel = np.ones((1, nlat, nlon, predicted_channels), dtype=model_input_hrrr.dtype)
-                    model_input = np.concatenate(
-                        [
-                            model_input_hrrr[:, :, :, :predicted_channels],
-                            model_input_gfs[0:1, :, :, :],
-                            rand_channel,
-                            model_input_hrrr[:, :, :, predicted_channels:],
-                            date_channel,
-                            step_channel,
-                            lead_channel
-                        ],
-                        axis=-1
-                    )
-                else:
-                    model_input = np.concatenate(
-                        [
-                            model_input_hrrr[:, :, :, :predicted_channels],
-                            model_input_gfs[0:1, :, :, :],
-                            model_input_hrrr[:, :, :, predicted_channels:],
-                            date_channel,
-                            step_channel,
-                            lead_channel
-                        ],
-                        axis=-1
-                    )
-
-            with profile_region("tf.forecaster_init"):
-                forecaster = WeatherForecaster(data_loader_hrrr, data_loader_gfs,
-                                                args.num_members, members,
-                                                args.batch_size, not args.no_diffusion,
-                                                args.lead_hours,
-                                                predicted_channels=predicted_channels,
-                                                gfs_channels=gfs_channels,
-                                                static_channels=static_channels,
-                                                pmm_alpha=args.pmm_alpha,
-                                                use_nudging=not args.no_nudging,
-                                                noise_rho=args.noise_rho)
-            run_weather_forecast(
-                forecaster, model, args.lead_hours, model_input, args.output_dir
+        if not args.no_diffusion:
+            rand_channel = np.ones((1, nlat, nlon, predicted_channels), dtype=model_input_hrrr.dtype)
+            model_input = np.concatenate(
+                [
+                    model_input_hrrr[:, :, :, :predicted_channels],
+                    model_input_gfs[0:1, :, :, :],
+                    rand_channel,
+                    model_input_hrrr[:, :, :, predicted_channels:],
+                    date_channel,
+                    step_channel,
+                    lead_channel
+                ],
+                axis=-1
             )
+        else:
+            model_input = np.concatenate(
+                [
+                    model_input_hrrr[:, :, :, :predicted_channels],
+                    model_input_gfs[0:1, :, :, :],
+                    model_input_hrrr[:, :, :, predicted_channels:],
+                    date_channel,
+                    step_channel,
+                    lead_channel
+                ],
+                axis=-1
+            )
+        
+        forecaster = WeatherForecaster(data_loader_hrrr, data_loader_gfs,
+                                        args.num_members, members,
+                                        args.batch_size, not args.no_diffusion,
+                                        args.lead_hours,
+                                        predicted_channels=predicted_channels,
+                                        gfs_channels=gfs_channels,
+                                        static_channels=static_channels,
+                                        pmm_alpha=args.pmm_alpha,
+                                        use_nudging=not args.no_nudging,
+                                        noise_rho=args.noise_rho)
+        run_weather_forecast(
+            forecaster, model, args.lead_hours, model_input, args.output_dir
+        )
         logger.info(f"All forecasts complete.")
         
     except Exception as e:

--- a/src/fcst.py
+++ b/src/fcst.py
@@ -14,6 +14,7 @@ import logging
 import os
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
@@ -21,11 +22,62 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import numpy as np
 import tensorflow as tf
-import xarray as xr
 import pandas as pd
-from skimage.exposure import match_histograms
 
-from nc2grib import Netcdf2Grib
+_PROFILE_TRUE = {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
+_BENCH_SKIP_OUTPUT = os.environ.get("HRRRCAST_BENCH_SKIP_OUTPUT", "") in _PROFILE_TRUE
+
+try:
+    import xarray as xr
+except ImportError:
+    if not _BENCH_SKIP_OUTPUT:
+        raise
+
+    class _ArrayWithValues:
+        def __init__(self, values):
+            self.values = values
+
+    class _H5NormDataset:
+        def __init__(self, path):
+            import h5py
+
+            self._h5 = h5py.File(path, "r")
+            self.variables = set(self._h5.keys())
+
+        def __getitem__(self, key):
+            return _ArrayWithValues(np.asarray(self._h5[key]))
+
+        def close(self):
+            self._h5.close()
+
+    class _XarrayShim:
+        Dataset = object
+        DataArray = object
+
+        @staticmethod
+        def open_dataset(path, *args, **kwargs):
+            return _H5NormDataset(path)
+
+    xr = _XarrayShim()
+
+try:
+    from skimage.exposure import match_histograms
+except ImportError:
+    if not _BENCH_SKIP_OUTPUT:
+        raise
+
+    def match_histograms(image, reference, channel_axis=None):
+        return image
+
+try:
+    from nc2grib import Netcdf2Grib
+except ImportError:
+    if not _BENCH_SKIP_OUTPUT:
+        raise
+
+    class Netcdf2Grib:
+        def save_grib2(self, *args, **kwargs):
+            raise RuntimeError("Netcdf2Grib is unavailable in HRRRCAST_BENCH_SKIP_OUTPUT mode")
 
 # Import custom modules (assuming they exist)
 try:
@@ -50,9 +102,100 @@ from transform import (
 import utils
 from utils import setup_logging
 from diagnostics import compute_diagnostics
-from compute_pmm import compute_PMM
+try:
+    from compute_pmm import compute_PMM
+except ImportError:
+    if not _BENCH_SKIP_OUTPUT:
+        raise
+
+    def compute_PMM(*args, **kwargs):
+        raise RuntimeError("compute_PMM is unavailable in HRRRCAST_BENCH_SKIP_OUTPUT mode")
 
 logger = None
+
+
+def _profile_env(name: str) -> bool:
+    return os.environ.get(name, "") in _PROFILE_TRUE
+
+
+def _profile_timing_enabled() -> bool:
+    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_PROFILE_TIMING")
+
+
+def _profile_nvtx_enabled() -> bool:
+    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_NVTX")
+
+
+def _profile_sync_enabled() -> bool:
+    return _profile_env("HRRRCAST_PROFILE") or _profile_env("HRRRCAST_SYNC_TIMING")
+
+
+def _profile_log(message: str, *args) -> None:
+    if logger is not None:
+        logger.info(message, *args)
+    else:
+        logging.info(message, *args)
+
+
+def _tf_sync_if_enabled() -> None:
+    if not _profile_sync_enabled():
+        return
+    async_wait = getattr(getattr(tf, "experimental", None), "async_wait", None)
+    if async_wait is not None:
+        async_wait()
+
+
+def _nvtx_push(name: str) -> bool:
+    if not _profile_nvtx_enabled():
+        return False
+    try:
+        import nvtx  # type: ignore
+    except Exception:
+        return False
+    if hasattr(nvtx, "push_range"):
+        nvtx.push_range(name)
+        return True
+    if hasattr(nvtx, "range_push"):
+        nvtx.range_push(name)
+        return True
+    return False
+
+
+def _nvtx_pop() -> None:
+    try:
+        import nvtx  # type: ignore
+    except Exception:
+        return
+    if hasattr(nvtx, "pop_range"):
+        nvtx.pop_range()
+    elif hasattr(nvtx, "range_pop"):
+        nvtx.range_pop()
+
+
+@contextmanager
+def profile_region(name: str, extra: str = "", detail: bool = False):
+    """Optional source-level timing/NVTX instrumentation."""
+    if detail and not _profile_env("HRRRCAST_PROFILE_DETAIL"):
+        yield
+        return
+
+    do_timing = _profile_timing_enabled()
+    if not (do_timing or _profile_nvtx_enabled() or _profile_sync_enabled()):
+        yield
+        return
+
+    _tf_sync_if_enabled()
+    pushed = _nvtx_push(name)
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        _tf_sync_if_enabled()
+        elapsed = time.perf_counter() - t0
+        if pushed:
+            _nvtx_pop()
+        if do_timing:
+            _profile_log("BENCH phase=%s%s seconds=%.6f", name, extra, elapsed)
 
 
 def make_noise(
@@ -91,34 +234,35 @@ class PreprocessedDataLoader:
         """Load preprocessed data from file."""
         if not os.path.exists(self.preprocessed_file):
             raise FileNotFoundError(f"Preprocessed data file not found: {self.preprocessed_file}")
-        
-        try:
-            logger.info(f"Loading preprocessed data from {self.preprocessed_file}")
-            self.data = np.load(self.preprocessed_file)
-            
-            # Extract metadata
-            self.metadata = {
-                'init_year': str(self.data['init_year']),
-                'init_month': str(self.data['init_month']),
-                'init_day': str(self.data['init_day']),
-                'init_hh': str(self.data['init_hh']),
-                'init_datetime': str(self.data['init_datetime']),
-                'pl_vars': self.data['pl_vars'].tolist(),
-                'sfc_vars': self.data['sfc_vars'].tolist(),
-                'levels': self.data['levels'].tolist(),
-                'grid_height': int(self.data['grid_height']),
-                'grid_width': int(self.data['grid_width']),
-                'downsample_factor': int(self.data['downsample_factor']),
-                'norm_file': str(self.data['norm_file'])
-            }
-            
-            logger.info("Preprocessed data loaded successfully")
-            logger.info(f"Model input shape: {self.data['model_input'].shape}")
-            logger.info(f"Initialization time: {self.metadata['init_datetime']}")
-            
-        except Exception as e:
-            logger.error(f"Error loading preprocessed data: {e}")
-            raise
+
+        with profile_region("tf.data_load", extra=f" file={Path(self.preprocessed_file).name}"):
+            try:
+                logger.info(f"Loading preprocessed data from {self.preprocessed_file}")
+                self.data = np.load(self.preprocessed_file)
+                
+                # Extract metadata
+                self.metadata = {
+                    'init_year': str(self.data['init_year']),
+                    'init_month': str(self.data['init_month']),
+                    'init_day': str(self.data['init_day']),
+                    'init_hh': str(self.data['init_hh']),
+                    'init_datetime': str(self.data['init_datetime']),
+                    'pl_vars': self.data['pl_vars'].tolist(),
+                    'sfc_vars': self.data['sfc_vars'].tolist(),
+                    'levels': self.data['levels'].tolist(),
+                    'grid_height': int(self.data['grid_height']),
+                    'grid_width': int(self.data['grid_width']),
+                    'downsample_factor': int(self.data['downsample_factor']),
+                    'norm_file': str(self.data['norm_file'])
+                }
+                
+                logger.info("Preprocessed data loaded successfully")
+                logger.info(f"Model input shape: {self.data['model_input'].shape}")
+                logger.info(f"Initialization time: {self.metadata['init_datetime']}")
+                
+            except Exception as e:
+                logger.error(f"Error loading preprocessed data: {e}")
+                raise
     
     def get_model_input(self) -> np.ndarray:
         """Get the model input array."""
@@ -139,8 +283,10 @@ class ForecastModel:
     def __init__(self, model_path: str):
         self.model_path = model_path
         self.model = None
-        self._setup_tf_environment()
-        self._load_model()
+        with profile_region("tf.tf_setup"):
+            self._setup_tf_environment()
+        with profile_region("tf.model_load"):
+            self._load_model()
 
     def _setup_tf_environment(self) -> None:
         """ 
@@ -188,7 +334,8 @@ class ForecastModel:
             raise RuntimeError("Model not loaded")
         
         try:
-            return self.model(input_data, training=False)
+            with profile_region("tf.model_forward", detail=True):
+                return self.model(input_data, training=False)
         except Exception as e:
             logger.error(f"Error during model prediction: {e}")
             raise
@@ -260,16 +407,17 @@ class WeatherForecaster:
 
         # Load normalization file and construct per-channel mean/std vectors consistent with preprocessing
         norm_file = self.metadata["norm_file"]
-        try:
-            ds_norm = xr.open_dataset(norm_file)
-            self._init_channel_stats(ds_norm)
-            ds_norm.close()
-            logger.info(
-                f"Normalization file loaded and channel stats constructed: {norm_file}"
-            )
-        except Exception as e:
-            logger.error(f"Error loading/processing normalization file: {e}")
-            raise
+        with profile_region("tf.norm_stats_load"):
+            try:
+                ds_norm = xr.open_dataset(norm_file)
+                self._init_channel_stats(ds_norm)
+                ds_norm.close()
+                logger.info(
+                    f"Normalization file loaded and channel stats constructed: {norm_file}"
+                )
+            except Exception as e:
+                logger.error(f"Error loading/processing normalization file: {e}")
+                raise
 
         # Initialize per-member base noise anchors (on-the-fly generation in predict)
         logger.info(f"Initializing member anchors for {len(self.members)} members")
@@ -601,13 +749,14 @@ class WeatherForecaster:
         """
         t0 = time.time()
 
-        # Denormalize to physical units
-        denorm = self.denormalize(forecast_norm)
-        # Ensure shape (time=1, Ny, Nx, C)
-        if denorm.ndim == 3:
-            denorm = denorm[None, ...]
-        times = [hour]
-        ds_hour = self.create_xarray_dataset(init_datetime, times, lats, lons, denorm)
+        with profile_region("tf.output_build", extra=f" hour={hour}"):
+            # Denormalize to physical units
+            denorm = self.denormalize(forecast_norm)
+            # Ensure shape (time=1, Ny, Nx, C)
+            if denorm.ndim == 3:
+                denorm = denorm[None, ...]
+            times = [hour]
+            ds_hour = self.create_xarray_dataset(init_datetime, times, lats, lons, denorm)
 
         # Inject constants if present in preprocessed NPZ (repeat across lead_time length 1)
         for cname in ["LAND", "OROG"]:
@@ -665,7 +814,8 @@ class WeatherForecaster:
         if mem_str not in {"avg", "spr"}:
             mem_str = f"m{int(member):02d}"
         nc_path = outdir / f"hrrrcast_{mem_str}_f{hour:02d}.nc"
-        ds_hour.to_netcdf(nc_path)
+        with profile_region("tf.netcdf_write", extra=f" hour={hour} member={member}"):
+            ds_hour.to_netcdf(nc_path)
 
         write_time = time.time() - t0
         logger.info(f"Wrote NetCDF in {write_time:.3f}s : {nc_path}")
@@ -706,7 +856,8 @@ class WeatherForecaster:
                 ds_hour = ds_hour.assign_coords(lead_time=("lead_time", [hour]))
             except Exception:
                 pass
-        converter.save_grib2(init_datetime, ds_hour, str(grib2_path))
+        with profile_region("tf.grib2_write", extra=f" hour={hour} member={member}"):
+            converter.save_grib2(init_datetime, ds_hour, str(grib2_path))
 
         write_time = time.time() - t0
         logger.info(f"Wrote GRIB2 in {write_time:.3f}s : {grib2_path}")
@@ -949,6 +1100,9 @@ class WeatherForecaster:
 
         def build_and_submit_hour_outputs(hour: int, data: np.ndarray, member: int) -> None:
             """Build the dataset in a worker, then submit both file writes."""
+            if _BENCH_SKIP_OUTPUT:
+                logger.debug(f"Skipping output build/write for hour {hour} member {member}")
+                return
             try:
                 ds_hour = self.build_single_hour_dataset(init_datetime, hour, lats, lons, data)
             except Exception as e:
@@ -1051,7 +1205,11 @@ class WeatherForecaster:
                 
                 # Predict next-hour fields for entire batch using hour-specific noise
                 t0 = time.time()
-                y_batch = self.predict(model, X_batch, batch_members_list, hour=hour)
+                with profile_region(
+                    "tf.predict",
+                    extra=f" hour={hour} batch={batch_start//batch_size + 1} members={batch_members_list}",
+                ):
+                    y_batch = self.predict(model, X_batch, batch_members_list, hour=hour)
                 predict_time = time.time() - t0
                 logger.info(f"Hour {hour}, batch {batch_start//batch_size + 1}: predict took {predict_time:.3f}s")
                 
@@ -1069,7 +1227,8 @@ class WeatherForecaster:
                     # state for this member
                     if hour % rollout_hour == 0:
                         state_from_hour[member] = y
-                    hour_member_outputs[member] = y.numpy().copy()
+                    with profile_region("tf.output_stage", extra=f" hour={hour} member={member}"):
+                        hour_member_outputs[member] = y.numpy().copy()
 
             # Compute PMM mean for this hour and nudge members before writing (if enabled)
             if self.use_nudging:
@@ -1089,14 +1248,15 @@ class WeatherForecaster:
         # Wait for all background work to complete. Build tasks must drain first so
         # they cannot submit into executors that are already shutting down.
         logger.info(f"Waiting for {len(build_futures)} background build operations to complete...")
-        for future in as_completed(build_futures):
-            try:
-                future.result()
-            except Exception as e:
-                logger.error(f"Background build operation failed: {e}")
-        build_executor.shutdown(wait=True)
-        nc_executor.shutdown(wait=True)
-        grib2_executor.shutdown(wait=True)
+        with profile_region("tf.output_wait"):
+            for future in as_completed(build_futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.error(f"Background build operation failed: {e}")
+            build_executor.shutdown(wait=True)
+            nc_executor.shutdown(wait=True)
+            grib2_executor.shutdown(wait=True)
         logger.info("All background output operations completed")
 
         logger.info("Autoregressive rollout completed")
@@ -1162,14 +1322,15 @@ class WeatherForecaster:
             logger.info(self.metadata)
 
             # Run autoregressive forecast and write per-hour outputs to disk
-            self.autoregressive_rollout(
-                model_input,
-                self.data_loader_gfs.get_model_input(),
-                model,
-                lead_hours,
-                output_dir=output_dir,
-                init_datetime=init_datetime,
-            )
+            with profile_region("tf.rollout_total"):
+                self.autoregressive_rollout(
+                    model_input,
+                    self.data_loader_gfs.get_model_input(),
+                    model,
+                    lead_hours,
+                    output_dir=output_dir,
+                    init_datetime=init_datetime,
+                )
             logger.info("Forecast completed successfully (per-hour outputs written during rollout)")
         except Exception as e:
             logger.error(f"Forecast failed: {e}")
@@ -1235,73 +1396,76 @@ def main():
             members.extend(expand_member_arg(m))
         members = sorted(set(members))  # Remove duplicates and sort
 
-        # Load preprocessed data and model ONCE
-        init_datetime, init_year, init_month, init_day, init_hh = utils.validate_datetime(args.inittime)
-        date_str = f"{init_year}{init_month}{init_day}/{init_hh}"
-        filedate_str = f"{init_year}{init_month}{init_day}_{init_hh}"
-        hrrr_preprocessed_file = f"{args.base_dir}/{date_str}/hrrr_{filedate_str}.npz"
-        gfs_preprocessed_file = f"{args.base_dir}/{date_str}/gfs_{filedate_str}.npz"
-        data_loader_hrrr = PreprocessedDataLoader(hrrr_preprocessed_file)
-        data_loader_gfs = PreprocessedDataLoader(gfs_preprocessed_file)
-        model = ForecastModel(args.model_path)
+        with profile_region("tf.total_process"):
+            # Load preprocessed data and model ONCE
+            init_datetime, init_year, init_month, init_day, init_hh = utils.validate_datetime(args.inittime)
+            date_str = f"{init_year}{init_month}{init_day}/{init_hh}"
+            filedate_str = f"{init_year}{init_month}{init_day}_{init_hh}"
+            hrrr_preprocessed_file = f"{args.base_dir}/{date_str}/hrrr_{filedate_str}.npz"
+            gfs_preprocessed_file = f"{args.base_dir}/{date_str}/gfs_{filedate_str}.npz"
+            data_loader_hrrr = PreprocessedDataLoader(hrrr_preprocessed_file)
+            data_loader_gfs = PreprocessedDataLoader(gfs_preprocessed_file)
+            model = ForecastModel(args.model_path)
 
-        # Precompute model_input ONCE
-        model_input_hrrr = data_loader_hrrr.get_model_input()
-        model_input_gfs = data_loader_gfs.get_model_input()
+            # Precompute model_input ONCE
+            with profile_region("tf.tensor_prep"):
+                model_input_hrrr = data_loader_hrrr.get_model_input()
+                model_input_gfs = data_loader_gfs.get_model_input()
 
-        pl_vars = data_loader_hrrr.metadata["pl_vars"]
-        sfc_vars = data_loader_hrrr.metadata["sfc_vars"]
-        levels = data_loader_hrrr.metadata["levels"]
-        predicted_channels = len(pl_vars) * len(levels) + len(sfc_vars)
-        gfs_channels = model_input_gfs.shape[-1]
-        static_channels = max(model_input_hrrr.shape[-1] - predicted_channels, 0)
+                pl_vars = data_loader_hrrr.metadata["pl_vars"]
+                sfc_vars = data_loader_hrrr.metadata["sfc_vars"]
+                levels = data_loader_hrrr.metadata["levels"]
+                predicted_channels = len(pl_vars) * len(levels) + len(sfc_vars)
+                gfs_channels = model_input_gfs.shape[-1]
+                static_channels = max(model_input_hrrr.shape[-1] - predicted_channels, 0)
 
-        nlat = model_input_hrrr.shape[1]
-        nlon = model_input_hrrr.shape[2]
-        date_channel = np.ones((1, nlat, nlon, 6), dtype=model_input_hrrr.dtype)
-        lead_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
-        step_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
+                nlat = model_input_hrrr.shape[1]
+                nlon = model_input_hrrr.shape[2]
+                date_channel = np.ones((1, nlat, nlon, 6), dtype=model_input_hrrr.dtype)
+                lead_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
+                step_channel = np.ones((1, nlat, nlon, 1), dtype=model_input_hrrr.dtype)
 
-        if not args.no_diffusion:
-            rand_channel = np.ones((1, nlat, nlon, predicted_channels), dtype=model_input_hrrr.dtype)
-            model_input = np.concatenate(
-                [
-                    model_input_hrrr[:, :, :, :predicted_channels],
-                    model_input_gfs[0:1, :, :, :],
-                    rand_channel,
-                    model_input_hrrr[:, :, :, predicted_channels:],
-                    date_channel,
-                    step_channel,
-                    lead_channel
-                ],
-                axis=-1
+                if not args.no_diffusion:
+                    rand_channel = np.ones((1, nlat, nlon, predicted_channels), dtype=model_input_hrrr.dtype)
+                    model_input = np.concatenate(
+                        [
+                            model_input_hrrr[:, :, :, :predicted_channels],
+                            model_input_gfs[0:1, :, :, :],
+                            rand_channel,
+                            model_input_hrrr[:, :, :, predicted_channels:],
+                            date_channel,
+                            step_channel,
+                            lead_channel
+                        ],
+                        axis=-1
+                    )
+                else:
+                    model_input = np.concatenate(
+                        [
+                            model_input_hrrr[:, :, :, :predicted_channels],
+                            model_input_gfs[0:1, :, :, :],
+                            model_input_hrrr[:, :, :, predicted_channels:],
+                            date_channel,
+                            step_channel,
+                            lead_channel
+                        ],
+                        axis=-1
+                    )
+
+            with profile_region("tf.forecaster_init"):
+                forecaster = WeatherForecaster(data_loader_hrrr, data_loader_gfs,
+                                                args.num_members, members,
+                                                args.batch_size, not args.no_diffusion,
+                                                args.lead_hours,
+                                                predicted_channels=predicted_channels,
+                                                gfs_channels=gfs_channels,
+                                                static_channels=static_channels,
+                                                pmm_alpha=args.pmm_alpha,
+                                                use_nudging=not args.no_nudging,
+                                                noise_rho=args.noise_rho)
+            run_weather_forecast(
+                forecaster, model, args.lead_hours, model_input, args.output_dir
             )
-        else:
-            model_input = np.concatenate(
-                [
-                    model_input_hrrr[:, :, :, :predicted_channels],
-                    model_input_gfs[0:1, :, :, :],
-                    model_input_hrrr[:, :, :, predicted_channels:],
-                    date_channel,
-                    step_channel,
-                    lead_channel
-                ],
-                axis=-1
-            )
-        
-        forecaster = WeatherForecaster(data_loader_hrrr, data_loader_gfs,
-                                        args.num_members, members,
-                                        args.batch_size, not args.no_diffusion,
-                                        args.lead_hours,
-                                        predicted_channels=predicted_channels,
-                                        gfs_channels=gfs_channels,
-                                        static_channels=static_channels,
-                                        pmm_alpha=args.pmm_alpha,
-                                        use_nudging=not args.no_nudging,
-                                        noise_rho=args.noise_rho)
-        run_weather_forecast(
-            forecaster, model, args.lead_hours, model_input, args.output_dir
-        )
         logger.info(f"All forecasts complete.")
         
     except Exception as e:

--- a/src_torch/__init__.py
+++ b/src_torch/__init__.py
@@ -1,0 +1,1 @@
+"""PyTorch inference port helpers for HRRRCast."""

--- a/src_torch/cli.py
+++ b/src_torch/cli.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Full multi-member, multi-hour HRRRCast forecast (PyTorch port of src/fcst.py).
+
+Pipeline:
+  1. Load HRRR + GFS preprocessed npz files.
+  2. Load the clean HRRRCast nn.Module.
+  3. Assemble the initial (1, 328, H, W) model input.
+  4. Run the autoregressive rollout, per-hour writing NetCDF (and optional GRIB2)
+     per ensemble member, with optional PMM nudging on REFC/APCP.
+
+Example:
+  python -m src_torch.cli forecast --init-time 2024-05-06T23 --lead-hours 1 --members 0
+  python -m src_torch.cli forecast --init-time 2024-05-06T23 --members 0-3 --batch-size 2
+  python -m src_torch.cli validate          # parity vs the TF reference dump
+
+Data and output locations default to ``$HRRRCAST_DATA`` (else ``<repo>/data``)
+and ``$HRRRCAST_ARTIFACTS/torch_ref/out`` (else ``<repo>/artifacts/...``);
+override with --base-dir / --output-dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import torch
+
+from .config import ARTIFACTS_ROOT
+from .inference import DEFAULT_SAMPLER, load_hrrrcast
+from .output import convert_netcdf_hours_to_grib2, static_fields_from_npz, write_hour
+from .variables import LEVELS, PL_VARS, SFC_VARS, channel_bounds
+from .rollout import (
+    autoregressive_rollout,
+    build_initial_input,
+    gfs_forcing_to_nchw,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_DATA = Path(os.environ.get("HRRRCAST_DATA", _REPO_ROOT / "data"))
+_DEFAULT_OUTPUT = ARTIFACTS_ROOT / "torch_ref" / "out"
+
+
+def expand_member_spec(specs: Iterable[str]) -> list[int]:
+    """Accept '0,1,2', '0-3', '0 1 2', and mixes thereof."""
+    out: list[int] = []
+    for spec in specs:
+        for part in spec.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if "-" in part:
+                lo, hi = part.split("-")
+                out.extend(range(int(lo), int(hi) + 1))
+            else:
+                out.append(int(part))
+    return sorted(set(out))
+
+
+def cycle_dir_from_init(init_time: str) -> Path:
+    date, hour = init_time.split("T")
+    return Path(date.replace("-", "")) / hour
+
+
+def data_files(base_dir: Path, init_time: str) -> tuple[Path, Path]:
+    date, hour = init_time.split("T")
+    yyyymmdd = date.replace("-", "")
+    cycle = base_dir / yyyymmdd / hour
+    return cycle / f"hrrr_{yyyymmdd}_{hour}.npz", cycle / f"gfs_{yyyymmdd}_{hour}.npz"
+
+
+# --- PMM nudging (REFC/APCP only) -----------------------------------------
+
+def _maybe_nudge(
+    hour_outputs: dict[int, torch.Tensor],
+    *,
+    alpha: float,
+) -> dict[int, torch.Tensor]:
+    """Blend each member's REFC/APCP fields toward the PMM mean.
+
+    Returns a dict of (1, H, W, C) NHWC float32 tensors. Falls back to identity
+    when scikit-image or the `src/compute_pmm.compute_PMM` is unavailable, or when there
+    are fewer than two members.
+    """
+    if len(hour_outputs) < 2 or alpha >= 1.0:
+        return hour_outputs
+
+    try:
+        import xarray as xr  # local import to avoid mandatory dependency at module import time
+        from skimage.exposure import match_histograms
+
+        from .config import add_src_to_path
+
+        add_src_to_path()
+        from compute_pmm import compute_PMM  # type: ignore[import-not-found]
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger(__name__).warning("PMM nudging disabled: %s", exc)
+        return hour_outputs
+
+    num_pl = len(PL_VARS) * len(LEVELS)
+    refc_idx = num_pl + SFC_VARS.index("REFC") if "REFC" in SFC_VARS else None
+    apcp_idx = num_pl + SFC_VARS.index("APCP") if "APCP" in SFC_VARS else None
+    channels = [c for c in (refc_idx, apcp_idx) if c is not None]
+    if not channels:
+        return hour_outputs
+
+    members_sorted = sorted(hour_outputs.keys())
+    stack = np.stack([hour_outputs[m].detach().cpu().numpy()[0] for m in members_sorted], axis=0)
+    pmm_arrays: dict[int, np.ndarray] = {}
+    for channel in channels:
+        if channel >= stack.shape[-1]:
+            continue
+        da = xr.DataArray(
+            np.transpose(stack[:, :, :, channel], (1, 2, 0)),
+            dims=("latitude", "longitude", "member"),
+            coords={"member": np.arange(len(members_sorted))},
+        )
+        pmm_arrays[channel] = compute_PMM(da, method=2).values
+
+    nudged: dict[int, torch.Tensor] = {}
+    for i, member in enumerate(members_sorted):
+        arr = stack[i].copy()
+        for channel, pmm_vals in pmm_arrays.items():
+            member_channel = stack[i, :, :, channel]
+            blended = alpha * member_channel + (1.0 - alpha) * pmm_vals
+            arr[:, :, channel] = match_histograms(blended, member_channel, channel_axis=None)
+        nudged[member] = torch.from_numpy(arr[None, ...]).to(device=hour_outputs[member].device, dtype=hour_outputs[member].dtype)
+    return nudged
+
+
+# --- main -----------------------------------------------------------------
+
+def add_forecast_args(parser: argparse.ArgumentParser) -> None:
+    # TF-compatible positionals so jobs/job-fcst.sh can drive this as a drop-in
+    # for `src/fcst.py <model> <INIT> <LEAD> ...`. All optional; the --init-time
+    # / --lead-hours flags still work for standalone use.
+    parser.add_argument("model_path", nargs="?", default=None,
+                        help="(TF-compat) model path; ignored unless it ends with .pt (then used as --state-path)")
+    parser.add_argument("init_pos", nargs="?", default=None, help="(TF-compat) init time positional YYYY-MM-DDTHH")
+    parser.add_argument("lead_pos", nargs="?", default=None, help="(TF-compat) lead hours positional")
+    parser.add_argument("--init-time", dest="init_time", default="2024-05-06T23", help="YYYY-MM-DDTHH initialization time")
+    parser.add_argument("--lead-hours", dest="lead_hours", type=int, default=1, help="Maximum lead time in hours")
+    parser.add_argument("--members", nargs="+", default=["0"], help="Member ids, e.g. '0 1 2' or '0-3' or '0,1,2'")
+    parser.add_argument("--num-members", "--num_members", dest="num_members", type=int, default=None, help="Ensemble size (defaults to len(--members))")
+    parser.add_argument("--batch-size", "--batch_size", dest="batch_size", type=int, default=1, help="How many members to predict together each hour")
+    parser.add_argument("--sampler", default=DEFAULT_SAMPLER, choices=["dpmpp", "ddim"], help="Reverse-diffusion sampler (dpmpp = upstream ea1b4ed)")
+    parser.add_argument("--base-dir", "--base_dir", dest="base_dir", default=str(_DEFAULT_DATA))
+    parser.add_argument("--output-dir", "--output_dir", dest="output_dir", default=str(_DEFAULT_OUTPUT))
+    parser.add_argument("--state-path", "--state_path", dest="state_path", default=None, help="Override module state dict path")
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--pmm-alpha", "--pmm_alpha", dest="pmm_alpha", type=float, default=0.7, help="Blend factor toward PMM mean (1.0 disables nudging)")
+    parser.add_argument("--noise-rho", "--noise_rho", dest="noise_rho", type=float, default=0.9, help="AR(1) member-noise correlation coefficient")
+    parser.add_argument("--no-nudging", "--no_nudging", dest="no_nudging", action="store_true", help="Disable PMM nudging regardless of --pmm-alpha")
+    parser.add_argument("--no-diffusion", "--no_diffusion", dest="no_diffusion", action="store_true", help="(TF-compat) accepted but unsupported; the PyTorch port always runs diffusion")
+    parser.add_argument("--no-grib2", "--no_grib2", dest="no_grib2", action="store_true", help="Skip GRIB2 conversion (NetCDF only)")
+    parser.add_argument("--compile", action="store_true", help="torch.compile the model (fuses elementwise/LayerNorm, cuts launch overhead)")
+    parser.add_argument(
+        "--compile-mode", "--compile_mode", dest="compile_mode",
+        default="default",
+        choices=["default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"],
+        help="torch.compile mode (only used with --compile)",
+    )
+    parser.add_argument("--log-level", "--log_level", dest="log_level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+
+
+def run_forecast(args: argparse.Namespace) -> None:
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    logger = logging.getLogger("fcst")
+
+    # Resolve TF-compatible positionals (if given) over the named flags.
+    init_time = args.init_pos if args.init_pos is not None else args.init_time
+    lead_hours = int(args.lead_pos) if args.lead_pos is not None else args.lead_hours
+    state_path = args.state_path
+    if args.model_path and args.model_path.endswith(".pt"):
+        state_path = args.model_path
+    if args.no_diffusion:
+        logger.warning("--no-diffusion is not supported by the PyTorch port; ignoring (diffusion always on).")
+
+    members = expand_member_spec(args.members)
+    if not members:
+        raise SystemExit("No members requested")
+    num_members = args.num_members or len(members)
+
+    hrrr_path, gfs_path = data_files(Path(args.base_dir), init_time)
+    if not hrrr_path.exists():
+        raise SystemExit(f"HRRR npz missing: {hrrr_path}")
+    if not gfs_path.exists():
+        raise SystemExit(f"GFS npz missing: {gfs_path}")
+
+    hrrr_npz = np.load(hrrr_path)
+    gfs_npz = np.load(gfs_path)
+    init_datetime = datetime.fromisoformat(str(hrrr_npz["init_datetime"]))
+    lats = np.asarray(hrrr_npz["lats"])
+    lons = np.asarray(hrrr_npz["lons"])
+    # np.load's NpzFile re-reads/decompresses on every __getitem__, so pull the
+    # large GFS forcing block out once and reuse it (shape, initial input, forcing).
+    gfs_model_input = np.asarray(gfs_npz["model_input"])
+
+    forcing_hours_available = int(gfs_model_input.shape[0])
+    if lead_hours > forcing_hours_available:
+        logger.warning(
+            "Requested %d lead hours but GFS npz only has %d forcing hour(s); rollout will clip to the last available index.",
+            lead_hours,
+            forcing_hours_available,
+        )
+
+    device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    logger.info("Loading HRRRCast model on %s%s", device, " (torch.compile)" if args.compile else "")
+    model = load_hrrrcast(state_path, device=device, compile_model=args.compile, compile_mode=args.compile_mode)
+
+    initial_input = build_initial_input(hrrr_npz, gfs_model_input, device=device)
+    gfs_forcing = gfs_forcing_to_nchw(gfs_model_input, device=device)
+    mins, maxs = channel_bounds(device=device)
+    cycle_out = Path(args.output_dir) / cycle_dir_from_init(init_time)
+    cycle_out.mkdir(parents=True, exist_ok=True)
+    static_fields = static_fields_from_npz(hrrr_npz)
+
+    # Buffer one hour's worth of member outputs so PMM can run on the full
+    # ensemble before we hand off to the writer. Writes happen in a background
+    # thread to overlap with the next hour's inference.
+    io_executor = ThreadPoolExecutor(max_workers=1)
+    io_futures: list = []
+    nudging_enabled = (not args.no_nudging) and len(members) >= 2 and args.pmm_alpha < 1.0
+    hour_buffer: dict[int, dict[int, torch.Tensor]] = {}
+
+    def schedule_write(hour: int, member: int, normalized_nhwc: torch.Tensor) -> None:
+        io_futures.append(
+            io_executor.submit(
+                write_hour,
+                normalized=normalized_nhwc,
+                hour=hour,
+                static_fields=static_fields,
+                init_datetime=init_datetime,
+                lats=lats,
+                lons=lons,
+                output_dir=cycle_out,
+                member=member,
+            )
+        )
+
+    def flush_hour(hour: int) -> None:
+        outputs = hour_buffer.pop(hour, {})
+        if not outputs:
+            return
+        finalized = _maybe_nudge(outputs, alpha=args.pmm_alpha) if nudging_enabled else outputs
+        for member, tensor in finalized.items():
+            schedule_write(hour, member, tensor)
+
+    def on_hour(hour: int, member: int, normalized_nhwc: torch.Tensor) -> None:
+        hour_buffer.setdefault(hour, {})[member] = normalized_nhwc.detach().cpu()
+        if len(hour_buffer[hour]) == len(members):
+            flush_hour(hour)
+
+    autoregressive_rollout(
+        model,
+        init_input=initial_input,
+        gfs_forcing=gfs_forcing,
+        members=members,
+        num_members=num_members,
+        lead_hours=lead_hours,
+        init_datetime=init_datetime,
+        channel_mins=mins,
+        channel_maxs=maxs,
+        batch_size=args.batch_size,
+        on_hour=on_hour,
+        sampler=args.sampler,
+        noise_rho=args.noise_rho,
+    )
+
+    # Flush any partially filled hour buckets (shouldn't happen with correct
+    # member tracking but is a safety net).
+    for hour in sorted(hour_buffer):
+        flush_hour(hour)
+
+    written_nc: list[Path] = []
+    for future in as_completed(io_futures):
+        written_nc.append(future.result())
+    io_executor.shutdown(wait=True)
+    logger.info("Wrote %d NetCDF files under %s", len(written_nc), cycle_out)
+
+    if not args.no_grib2:
+        try:
+            hours = list(range(0, lead_hours + 1))
+            for member in members:
+                convert_netcdf_hours_to_grib2(
+                    init_time=init_time,
+                    member=member,
+                    hours=hours,
+                    in_dir=cycle_out,
+                    out_dir=cycle_out,
+                )
+            logger.info("Wrote GRIB2 for members %s hours %s", members, hours)
+        except ModuleNotFoundError as exc:
+            if exc.name in {"grib2io", "eccodes"}:
+                logger.warning(
+                    "grib2io / eccodes not available; skipping GRIB2 in-process. "
+                    "Run scripts/convert_torch_netcdf_to_grib2.py to convert via the micromamba fallback."
+                )
+            else:
+                raise
+
+    print(
+        {
+            "init_time": init_time,
+            "lead_hours": lead_hours,
+            "members": members,
+            "output_dir": str(cycle_out),
+            "netcdf_count": len(written_nc),
+            "device": str(device),
+        }
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="HRRRCast PyTorch inference (forecast / validate)")
+    sub = parser.add_subparsers(dest="command")
+    add_forecast_args(sub.add_parser("forecast", help="Multi-member, multi-hour forecast (NetCDF + GRIB2)"))
+    vp = sub.add_parser("validate", help="Parity check vs a TF reference dump")
+    vp.add_argument("--dump", default=None, help="TF reference npz (defaults to $HRRRCAST_ARTIFACTS/tf_ref/...)")
+    vp.add_argument("--state", default=None, help="Override module state dict path")
+    vp.add_argument("--device", default=None)
+    vp.add_argument("--sampler", default=DEFAULT_SAMPLER, choices=["dpmpp", "ddim"])
+    vp.add_argument("--rollout-dump", default=None, help="TF rollout dump directory for validation-only noise replay")
+    vp.add_argument("--base-dir", default=None, help="Data root for rollout replay")
+    vp.add_argument("--init-time", default="2024-05-06T23")
+    vp.add_argument("--lead-hours", type=int, default=6)
+    vp.add_argument("--member", type=int, default=0)
+    vp.add_argument("--out", default=None, help="Optional path to write the JSON report")
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        from .validate import run as run_validate
+
+        kwargs = {
+            "state": args.state,
+            "device": args.device,
+            "sampler": args.sampler,
+            "out": args.out,
+            "rollout_dump": args.rollout_dump,
+            "base_dir": args.base_dir,
+            "init_time": args.init_time,
+            "lead_hours": args.lead_hours,
+            "member": args.member,
+        }
+        if args.dump:
+            kwargs["dump"] = args.dump
+        report, ok = run_validate(**kwargs)
+        print(json.dumps(report, indent=2))
+        raise SystemExit(0 if ok else 1)
+
+    if args.command == "forecast":
+        run_forecast(args)
+        return
+
+    parser.print_help()
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src_torch/cli.py
+++ b/src_torch/cli.py
@@ -35,6 +35,7 @@ import torch
 from .config import ARTIFACTS_ROOT
 from .inference import DEFAULT_SAMPLER, load_hrrrcast
 from .output import convert_netcdf_hours_to_grib2, static_fields_from_npz, write_hour
+from .profiling import profile_region
 from .variables import LEVELS, PL_VARS, SFC_VARS, channel_bounds
 from .rollout import (
     autoregressive_rollout,
@@ -197,14 +198,15 @@ def run_forecast(args: argparse.Namespace) -> None:
     if not gfs_path.exists():
         raise SystemExit(f"GFS npz missing: {gfs_path}")
 
-    hrrr_npz = np.load(hrrr_path)
-    gfs_npz = np.load(gfs_path)
-    init_datetime = datetime.fromisoformat(str(hrrr_npz["init_datetime"]))
-    lats = np.asarray(hrrr_npz["lats"])
-    lons = np.asarray(hrrr_npz["lons"])
-    # np.load's NpzFile re-reads/decompresses on every __getitem__, so pull the
-    # large GFS forcing block out once and reuse it (shape, initial input, forcing).
-    gfs_model_input = np.asarray(gfs_npz["model_input"])
+    with profile_region("torch.data_load", logger=logger):
+        hrrr_npz = np.load(hrrr_path)
+        gfs_npz = np.load(gfs_path)
+        init_datetime = datetime.fromisoformat(str(hrrr_npz["init_datetime"]))
+        lats = np.asarray(hrrr_npz["lats"])
+        lons = np.asarray(hrrr_npz["lons"])
+        # np.load's NpzFile re-reads/decompresses on every __getitem__, so pull the
+        # large GFS forcing block out once and reuse it (shape, initial input, forcing).
+        gfs_model_input = np.asarray(gfs_npz["model_input"])
 
     forcing_hours_available = int(gfs_model_input.shape[0])
     if lead_hours > forcing_hours_available:
@@ -216,14 +218,16 @@ def run_forecast(args: argparse.Namespace) -> None:
 
     device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
     logger.info("Loading HRRRCast model on %s%s", device, " (torch.compile)" if args.compile else "")
-    model = load_hrrrcast(state_path, device=device, compile_model=args.compile, compile_mode=args.compile_mode)
+    with profile_region("torch.model_load", logger=logger):
+        model = load_hrrrcast(state_path, device=device, compile_model=args.compile, compile_mode=args.compile_mode)
 
-    initial_input = build_initial_input(hrrr_npz, gfs_model_input, device=device)
-    gfs_forcing = gfs_forcing_to_nchw(gfs_model_input, device=device)
-    mins, maxs = channel_bounds(device=device)
-    cycle_out = Path(args.output_dir) / cycle_dir_from_init(init_time)
-    cycle_out.mkdir(parents=True, exist_ok=True)
-    static_fields = static_fields_from_npz(hrrr_npz)
+    with profile_region("torch.tensor_prep", logger=logger):
+        initial_input = build_initial_input(hrrr_npz, gfs_model_input, device=device)
+        gfs_forcing = gfs_forcing_to_nchw(gfs_model_input, device=device)
+        mins, maxs = channel_bounds(device=device)
+        cycle_out = Path(args.output_dir) / cycle_dir_from_init(init_time)
+        cycle_out.mkdir(parents=True, exist_ok=True)
+        static_fields = static_fields_from_npz(hrrr_npz)
 
     # Buffer one hour's worth of member outputs so PMM can run on the full
     # ensemble before we hand off to the writer. Writes happen in a background
@@ -232,11 +236,11 @@ def run_forecast(args: argparse.Namespace) -> None:
     io_futures: list = []
     nudging_enabled = (not args.no_nudging) and len(members) >= 2 and args.pmm_alpha < 1.0
     hour_buffer: dict[int, dict[int, torch.Tensor]] = {}
+    bench_skip_output = os.environ.get("HRRRCAST_BENCH_SKIP_OUTPUT", "") in {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
 
-    def schedule_write(hour: int, member: int, normalized_nhwc: torch.Tensor) -> None:
-        io_futures.append(
-            io_executor.submit(
-                write_hour,
+    def timed_write_hour(hour: int, member: int, normalized_nhwc: torch.Tensor) -> Path:
+        with profile_region("torch.output_write", logger=logger, extra=f" hour={hour} member={member}"):
+            return write_hour(
                 normalized=normalized_nhwc,
                 hour=hour,
                 static_fields=static_fields,
@@ -245,6 +249,18 @@ def run_forecast(args: argparse.Namespace) -> None:
                 lons=lons,
                 output_dir=cycle_out,
                 member=member,
+            )
+
+    def schedule_write(hour: int, member: int, normalized_nhwc: torch.Tensor) -> None:
+        if bench_skip_output:
+            logger.debug("Skipping output write for benchmark: hour=%s member=%s", hour, member)
+            return
+        io_futures.append(
+            io_executor.submit(
+                timed_write_hour,
+                hour,
+                member,
+                normalized_nhwc,
             )
         )
 
@@ -257,25 +273,27 @@ def run_forecast(args: argparse.Namespace) -> None:
             schedule_write(hour, member, tensor)
 
     def on_hour(hour: int, member: int, normalized_nhwc: torch.Tensor) -> None:
-        hour_buffer.setdefault(hour, {})[member] = normalized_nhwc.detach().cpu()
+        with profile_region("torch.output_stage", logger=logger, extra=f" hour={hour} member={member}"):
+            hour_buffer.setdefault(hour, {})[member] = normalized_nhwc.detach().cpu()
         if len(hour_buffer[hour]) == len(members):
             flush_hour(hour)
 
-    autoregressive_rollout(
-        model,
-        init_input=initial_input,
-        gfs_forcing=gfs_forcing,
-        members=members,
-        num_members=num_members,
-        lead_hours=lead_hours,
-        init_datetime=init_datetime,
-        channel_mins=mins,
-        channel_maxs=maxs,
-        batch_size=args.batch_size,
-        on_hour=on_hour,
-        sampler=args.sampler,
-        noise_rho=args.noise_rho,
-    )
+    with profile_region("torch.rollout_total", logger=logger):
+        autoregressive_rollout(
+            model,
+            init_input=initial_input,
+            gfs_forcing=gfs_forcing,
+            members=members,
+            num_members=num_members,
+            lead_hours=lead_hours,
+            init_datetime=init_datetime,
+            channel_mins=mins,
+            channel_maxs=maxs,
+            batch_size=args.batch_size,
+            on_hour=on_hour,
+            sampler=args.sampler,
+            noise_rho=args.noise_rho,
+        )
 
     # Flush any partially filled hour buckets (shouldn't happen with correct
     # member tracking but is a safety net).
@@ -283,22 +301,24 @@ def run_forecast(args: argparse.Namespace) -> None:
         flush_hour(hour)
 
     written_nc: list[Path] = []
-    for future in as_completed(io_futures):
-        written_nc.append(future.result())
-    io_executor.shutdown(wait=True)
+    with profile_region("torch.output_wait", logger=logger):
+        for future in as_completed(io_futures):
+            written_nc.append(future.result())
+        io_executor.shutdown(wait=True)
     logger.info("Wrote %d NetCDF files under %s", len(written_nc), cycle_out)
 
-    if not args.no_grib2:
+    if (not args.no_grib2) and (not bench_skip_output):
         try:
             hours = list(range(0, lead_hours + 1))
-            for member in members:
-                convert_netcdf_hours_to_grib2(
-                    init_time=init_time,
-                    member=member,
-                    hours=hours,
-                    in_dir=cycle_out,
-                    out_dir=cycle_out,
-                )
+            with profile_region("torch.grib2_write", logger=logger):
+                for member in members:
+                    convert_netcdf_hours_to_grib2(
+                        init_time=init_time,
+                        member=member,
+                        hours=hours,
+                        in_dir=cycle_out,
+                        out_dir=cycle_out,
+                    )
             logger.info("Wrote GRIB2 for members %s hours %s", members, hours)
         except ModuleNotFoundError as exc:
             if exc.name in {"grib2io", "eccodes"}:

--- a/src_torch/cli.py
+++ b/src_torch/cli.py
@@ -149,7 +149,7 @@ def add_forecast_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--members", nargs="+", default=["0"], help="Member ids, e.g. '0 1 2' or '0-3' or '0,1,2'")
     parser.add_argument("--num-members", "--num_members", dest="num_members", type=int, default=None, help="Ensemble size (defaults to len(--members))")
     parser.add_argument("--batch-size", "--batch_size", dest="batch_size", type=int, default=1, help="How many members to predict together each hour")
-    parser.add_argument("--sampler", default=DEFAULT_SAMPLER, choices=["dpmpp", "ddim"], help="Reverse-diffusion sampler (dpmpp = upstream ea1b4ed)")
+    parser.add_argument("--sampler", default=DEFAULT_SAMPLER, choices=["dpmpp", "ddim"], help="Reverse-diffusion sampler (dpmpp matches the current TensorFlow inference default)")
     parser.add_argument("--base-dir", "--base_dir", dest="base_dir", default=str(_DEFAULT_DATA))
     parser.add_argument("--output-dir", "--output_dir", dest="output_dir", default=str(_DEFAULT_OUTPUT))
     parser.add_argument("--state-path", "--state_path", dest="state_path", default=None, help="Override module state dict path")

--- a/src_torch/config.py
+++ b/src_torch/config.py
@@ -1,0 +1,28 @@
+"""Repository paths, artifact locations, and the `src/` utilities import shim."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Root for generated artifacts (converted weights, TF reference dumps, outputs).
+# Override with the HRRRCAST_ARTIFACTS environment variable; defaults to
+# `<repo>/artifacts`.
+ARTIFACTS_ROOT = Path(os.environ.get("HRRRCAST_ARTIFACTS", REPO_ROOT / "artifacts"))
+
+DEFAULT_MODEL_EXPORT = ARTIFACTS_ROOT / "model_export"
+DEFAULT_MODULE_STATE = Path(os.environ.get("HRRRCAST_MODULE_STATE", DEFAULT_MODEL_EXPORT / "hrrrcast_module_state_dict.pt"))
+DEFAULT_TENSOR_DUMP = ARTIFACTS_ROOT / "tf_ref" / "tensor_dump_ea1b4ed_mem0.npz"
+
+
+def add_src_to_path() -> Path:
+    """Add the model's `src/` to sys.path so its shared post-processing utilities
+    (`diagnostics.compute_diagnostics`, `compute_pmm.compute_PMM`,
+    `nc2grib.Netcdf2Grib`) can be imported and reused by the port."""
+    src_dir = REPO_ROOT / "src"
+    if str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+    return src_dir

--- a/src_torch/config.py
+++ b/src_torch/config.py
@@ -15,7 +15,7 @@ ARTIFACTS_ROOT = Path(os.environ.get("HRRRCAST_ARTIFACTS", REPO_ROOT / "artifact
 
 DEFAULT_MODEL_EXPORT = ARTIFACTS_ROOT / "model_export"
 DEFAULT_MODULE_STATE = Path(os.environ.get("HRRRCAST_MODULE_STATE", DEFAULT_MODEL_EXPORT / "hrrrcast_module_state_dict.pt"))
-DEFAULT_TENSOR_DUMP = ARTIFACTS_ROOT / "tf_ref" / "tensor_dump_ea1b4ed_mem0.npz"
+DEFAULT_TENSOR_DUMP = ARTIFACTS_ROOT / "tf_ref" / "tensor_dump_ref_mem0.npz"
 
 
 def add_src_to_path() -> Path:

--- a/src_torch/convert.py
+++ b/src_torch/convert.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Convert exported Keras weights to a clean `HRRRCast` state dict.
+
+By default this reads the committed `net-diffusion/model.keras` archive,
+extracts its `config.json` and `model.weights.h5`, and writes
+`$HRRRCAST_ARTIFACTS/model_export/hrrrcast_module_state_dict.pt`, whose keys
+match the `src_torch.model.HRRRCast` module hierarchy
+(e.g. `hrrr_pre.blocks.0.conv1.weight`).
+
+No intermediate Keras-named state dict is required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+
+import h5py
+import numpy as np
+import torch
+
+from .config import DEFAULT_MODEL_EXPORT, DEFAULT_MODULE_STATE, REPO_ROOT
+from .model import HRRRCast
+
+
+SPATIAL_GROUPED_NAMES = {
+    "encoder_0": [
+        ["spatial_grouped_conv2d", "spatial_grouped_conv2d_1"],
+        ["spatial_grouped_conv2d_2", "spatial_grouped_conv2d_3"],
+    ],
+    "decoder_2": [
+        ["spatial_grouped_conv2d_4", "spatial_grouped_conv2d_5"],
+        ["spatial_grouped_conv2d_6", "spatial_grouped_conv2d_7"],
+    ],
+}
+
+
+STACK_SPECS: list[dict] = [
+    {"module": "hrrr_pre", "keras_prefix": "hrrr_preprocessor", "n_blocks": 2},
+    {"module": "gfs_pre", "keras_prefix": "gfs_preprocessor", "n_blocks": 2},
+    {"module": "noised_pre", "keras_prefix": "hrrr_noised_preprocessor", "n_blocks": 2},
+    {"module": "enc0", "keras_prefix": "encoder_0", "n_blocks": 2},
+    {"module": "enc1", "keras_prefix": "encoder_1", "n_blocks": 3},
+    {"module": "enc2", "keras_prefix": "encoder_2", "n_blocks": 4},
+    {"module": "dec0", "keras_prefix": "decoder_0", "n_blocks": 4},
+    {"module": "dec1", "keras_prefix": "decoder_1", "n_blocks": 3},
+    {"module": "dec2", "keras_prefix": "decoder_2", "n_blocks": 2},
+    {"module": "output_refine", "keras_prefix": "output_refine", "n_blocks": 1},
+]
+
+
+def keras_group_name(class_name: str, index: int) -> str:
+    base = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", class_name)
+    base = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", base).lower()
+    base = base.replace("2_d", "2d")
+    return base if index == 0 else f"{base}_{index}"
+
+
+def assign_h5_paths(layers: list[dict], prefix: str, paths: dict[str, str]) -> None:
+    counts: dict[str, int] = defaultdict(int)
+    for layer in layers:
+        class_name = layer["class_name"]
+        name = layer["config"]["name"]
+        group = keras_group_name(class_name, counts[class_name])
+        counts[class_name] += 1
+        path = f"{prefix}/{group}"
+        paths[name] = path
+        if class_name == "RecomputeSubModel":
+            assign_h5_paths(layer["config"]["submodel"]["config"]["layers"], f"{path}/submodel/layers", paths)
+
+
+def build_keras_named_tensors(h5: h5py.File, layers: list[dict], paths: dict[str, str]) -> dict[str, torch.Tensor]:
+    """Pull tensors out of the Keras HDF5 file keyed by Keras layer name + suffix."""
+    native: dict[str, torch.Tensor] = {}
+    for layer in layers:
+        class_name = layer["class_name"]
+        name = layer["config"]["name"]
+        path = paths[name]
+        if class_name == "Dense":
+            native[f"{name}.weight"] = torch.from_numpy(np.asarray(h5[f"{path}/vars/0"])).t().contiguous()
+            if f"{path}/vars/1" in h5:
+                native[f"{name}.bias"] = torch.from_numpy(np.asarray(h5[f"{path}/vars/1"]))
+        elif class_name == "Conv2D":
+            native[f"{name}.weight"] = torch.from_numpy(np.asarray(h5[f"{path}/vars/0"])).permute(3, 2, 0, 1).contiguous()
+            if f"{path}/vars/1" in h5:
+                native[f"{name}.bias"] = torch.from_numpy(np.asarray(h5[f"{path}/vars/1"]))
+        elif class_name == "SpatialGroupedConv2D":
+            native[f"{name}.weight"] = torch.from_numpy(np.asarray(h5[f"{path}/conv/vars/0"])).permute(3, 2, 0, 1).contiguous()
+        elif class_name == "LayerNormalization":
+            group = f"{path}/vars"
+            if group not in h5:
+                continue
+            keys = sorted(h5[group].keys(), key=int)
+            offset = 0
+            if layer["config"].get("scale", True):
+                native[f"{name}.gamma"] = torch.from_numpy(np.asarray(h5[f"{group}/{keys[offset]}"]))
+                offset += 1
+            if layer["config"].get("center", True):
+                native[f"{name}.beta"] = torch.from_numpy(np.asarray(h5[f"{group}/{keys[offset]}"]))
+        elif class_name == "RecomputeSubModel":
+            native.update(build_keras_named_tensors(h5, layer["config"]["submodel"]["config"]["layers"], paths))
+    return native
+
+
+def block_conv_key(keras_prefix: str, block_idx_1based: int, sub: str) -> str:
+    if keras_prefix in SPATIAL_GROUPED_NAMES:
+        return SPATIAL_GROUPED_NAMES[keras_prefix][block_idx_1based - 1][int(sub) - 1] + ".weight"
+    return f"{keras_prefix}_res_{block_idx_1based}_{sub}_conv.weight"
+
+
+def remap_block(source: dict[str, torch.Tensor], keras_prefix: str, block_idx_1based: int, module_path: str) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    src_block_prefix = f"{keras_prefix}_res_{block_idx_1based}"
+
+    out[f"{module_path}.conv1.weight"] = source[block_conv_key(keras_prefix, block_idx_1based, "1")]
+    out[f"{module_path}.conv2.weight"] = source[block_conv_key(keras_prefix, block_idx_1based, "2")]
+
+    out[f"{module_path}.norm1.beta"] = source[f"{src_block_prefix}_1_lnorm.beta"]
+    out[f"{module_path}.norm2.gamma"] = source[f"{src_block_prefix}_2_lnorm.gamma"]
+    out[f"{module_path}.norm2.beta"] = source[f"{src_block_prefix}_2_lnorm.beta"]
+
+    for film in ("film_gamma", "film_beta"):
+        out[f"{module_path}.{film}.weight"] = source[f"{src_block_prefix}_{film}_dense.weight"]
+        out[f"{module_path}.{film}.bias"] = source[f"{src_block_prefix}_{film}_dense.bias"]
+
+    for mlp in ("cbam_ch_mlp_1", "cbam_ch_mlp_2"):
+        out[f"{module_path}.{mlp}.weight"] = source[f"{src_block_prefix}_{mlp}.weight"]
+        out[f"{module_path}.{mlp}.bias"] = source[f"{src_block_prefix}_{mlp}.bias"]
+
+    out[f"{module_path}.cbam_sp_conv7.weight"] = source[f"{src_block_prefix}_cbam_sp_conv7.weight"]
+
+    shortcut_key = f"{src_block_prefix}_0_conv.weight"
+    if shortcut_key in source:
+        out[f"{module_path}.shortcut.weight"] = source[shortcut_key]
+    return out
+
+
+def remap_processor(source: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    for module_idx in range(14):
+        block_idx_1based = module_idx + 1
+        prefix = f"processor_{module_idx}_res_{block_idx_1based}"
+        module_path = f"processor.blocks.{module_idx}"
+
+        out[f"{module_path}.conv1.weight"] = source[f"{prefix}_1_conv.weight"]
+        out[f"{module_path}.conv2.weight"] = source[f"{prefix}_2_conv.weight"]
+        out[f"{module_path}.norm1.beta"] = source[f"{prefix}_1_lnorm.beta"]
+        out[f"{module_path}.norm2.gamma"] = source[f"{prefix}_2_lnorm.gamma"]
+        out[f"{module_path}.norm2.beta"] = source[f"{prefix}_2_lnorm.beta"]
+        for film in ("film_gamma", "film_beta"):
+            out[f"{module_path}.{film}.weight"] = source[f"{prefix}_{film}_dense.weight"]
+            out[f"{module_path}.{film}.bias"] = source[f"{prefix}_{film}_dense.bias"]
+        for mlp in ("cbam_ch_mlp_1", "cbam_ch_mlp_2"):
+            out[f"{module_path}.{mlp}.weight"] = source[f"{prefix}_{mlp}.weight"]
+            out[f"{module_path}.{mlp}.bias"] = source[f"{prefix}_{mlp}.bias"]
+        out[f"{module_path}.cbam_sp_conv7.weight"] = source[f"{prefix}_cbam_sp_conv7.weight"]
+    return out
+
+
+def build_module_state(source: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+
+    out["time_dense.weight"] = source["time_dense.weight"]
+    out["time_dense.bias"] = source["time_dense.bias"]
+    out["time_norm.gamma"] = source["time_bn_relu_lnorm.gamma"]
+    out["time_norm.beta"] = source["time_bn_relu_lnorm.beta"]
+    out["skip1.weight"] = source["skip_scale_dense_1.weight"]
+    out["skip1.bias"] = source["skip_scale_dense_1.bias"]
+    out["skip2.weight"] = source["skip_scale_dense_2.weight"]
+    out["skip2.bias"] = source["skip_scale_dense_2.bias"]
+    out["output_conv.weight"] = source["output_refine_output_conv.weight"]
+
+    for spec in STACK_SPECS:
+        for module_idx in range(spec["n_blocks"]):
+            block_idx_1based = module_idx + 1
+            module_path = f"{spec['module']}.blocks.{module_idx}"
+            out.update(remap_block(source, spec["keras_prefix"], block_idx_1based, module_path))
+
+    out.update(remap_processor(source))
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--keras", default=str(REPO_ROOT / "net-diffusion" / "model.keras"), help="Keras .keras archive containing config.json and model.weights.h5")
+    parser.add_argument("--h5", default=None, help="Optional extracted model.weights.h5 override")
+    parser.add_argument("--config", default=None, help="Optional extracted config.json override")
+    parser.add_argument("--out", default=str(DEFAULT_MODULE_STATE))
+    args = parser.parse_args()
+
+    if bool(args.h5) != bool(args.config):
+        raise SystemExit("--h5 and --config must be provided together")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        if args.h5 and args.config:
+            h5_path = Path(args.h5)
+            config_path = Path(args.config)
+        else:
+            keras_path = Path(args.keras)
+            if not keras_path.exists():
+                raise SystemExit(f"Keras archive not found: {keras_path}")
+            with zipfile.ZipFile(keras_path) as zf:
+                zf.extract("config.json", tmp)
+                zf.extract("model.weights.h5", tmp)
+            h5_path = Path(tmp) / "model.weights.h5"
+            config_path = Path(tmp) / "config.json"
+
+        config_layers = json.loads(config_path.read_text())["config"]["layers"]
+        paths: dict[str, str] = {}
+        assign_h5_paths(config_layers, "layers", paths)
+
+        with h5py.File(h5_path, "r") as h5:
+            keras_named = build_keras_named_tensors(h5, config_layers, paths)
+
+    module_state = build_module_state(keras_named)
+
+    model = HRRRCast()
+    expected = set(model.state_dict().keys())
+    got = set(module_state.keys())
+    missing = sorted(expected - got)
+    extra = sorted(got - expected)
+    if missing or extra:
+        raise SystemExit({"missing": missing[:20], "missing_count": len(missing), "extra": extra[:20], "extra_count": len(extra)})
+    for key in expected:
+        if module_state[key].shape != model.state_dict()[key].shape:
+            raise SystemExit(f"shape mismatch for {key}: source {tuple(module_state[key].shape)} vs module {tuple(model.state_dict()[key].shape)}")
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(module_state, out_path)
+    print({
+        "out": str(out_path),
+        "tensors": len(module_state),
+        "params": sum(t.numel() for t in module_state.values()),
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/src_torch/diffusion.py
+++ b/src_torch/diffusion.py
@@ -6,8 +6,8 @@ import numpy as np
 import torch
 
 NUM_DIFFUSION_STEPS = 200
-# Upstream ea1b4ed: 25 uniformly-spaced inference steps with the dpmpp-2m sampler
-# (down from 50-step DDIM), allowing ~2x members at similar wall time.
+# Current TensorFlow inference path: 25 uniformly-spaced inference steps with
+# the DPM-Solver++(2M) sampler.
 NUM_INFERENCE_STEPS = 25
 
 
@@ -60,9 +60,9 @@ def dpmpp_2m(
 ) -> tuple[torch.Tensor, torch.Tensor, float]:
     """DPM-Solver++(2M) multistep update in x0-prediction space.
 
-    Faithful port of `src/diffusion_params.dpmpp_2m` (upstream ea1b4ed). First
-    step is first-order DPM-Solver++; subsequent steps add the 2nd-order
-    multistep correction using the previous step's x0 and lambda-step `prev_h`.
+    Faithful port of `src/diffusion_params.dpmpp_2m`. First step is first-order
+    DPM-Solver++; subsequent steps add the 2nd-order multistep correction using
+    the previous step's x0 and lambda-step `prev_h`.
     Returns `(x_{t-1}, x0_t, h)`; carry `x0_t`/`h` into the next call.
     """
     t = int(INFERENCE_STEPS[t_index])

--- a/src_torch/diffusion.py
+++ b/src_torch/diffusion.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import torch
+
+NUM_DIFFUSION_STEPS = 200
+# Upstream ea1b4ed: 25 uniformly-spaced inference steps with the dpmpp-2m sampler
+# (down from 50-step DDIM), allowing ~2x members at similar wall time.
+NUM_INFERENCE_STEPS = 25
+
+
+def cosine_beta_schedule(timesteps: int, s: float = 0.008) -> np.ndarray:
+    beta_start = 0.0001
+    beta_end = 0.9999
+
+    def alpha_bar_fn(t: int) -> float:
+        return np.cos((t / timesteps + s) / (1 + s) * np.pi / 2) ** 2
+
+    alphas_bar = np.array([alpha_bar_fn(t) for t in range(timesteps + 1)])
+    alphas_bar = alphas_bar / alphas_bar[0]
+    betas = 1 - (alphas_bar[1:] / alphas_bar[:-1])
+    return np.clip(betas, beta_start, beta_end)
+
+
+BETA = cosine_beta_schedule(NUM_DIFFUSION_STEPS).astype(np.float32)
+ALPHA = (1.0 - BETA).astype(np.float32)
+ALPHA_BAR = np.cumprod(ALPHA, axis=0).astype(np.float32)
+INFERENCE_STEPS = np.linspace(0, NUM_DIFFUSION_STEPS - 1, NUM_INFERENCE_STEPS).astype(np.int32)
+
+
+def compute_epsilon(x_t: torch.Tensor, x_0: torch.Tensor, t: int) -> torch.Tensor:
+    alpha_bar_t = torch.as_tensor(ALPHA_BAR[t], dtype=x_t.dtype, device=x_t.device)
+    return (x_t - x_0 * torch.sqrt(alpha_bar_t)) / torch.sqrt(1.0 - alpha_bar_t)
+
+
+def ddim(x_t: torch.Tensor, pred_noise: torch.Tensor, t_index: int, eta: float = 0.0) -> torch.Tensor:
+    t = int(INFERENCE_STEPS[t_index])
+    tm1 = int(INFERENCE_STEPS[t_index - 1])
+    alpha_bar_t = torch.as_tensor(ALPHA_BAR[t], dtype=x_t.dtype, device=x_t.device)
+    alpha_bar_tm1 = torch.as_tensor(ALPHA_BAR[tm1], dtype=x_t.dtype, device=x_t.device)
+
+    x0_pred = (x_t - torch.sqrt(1.0 - alpha_bar_t) * pred_noise) / torch.sqrt(alpha_bar_t)
+    if eta > 0.0:
+        r1 = (1.0 - alpha_bar_tm1) / (1.0 - alpha_bar_t + 1e-12)
+        r2 = 1.0 - (alpha_bar_t / (alpha_bar_tm1 + 1e-12))
+        sigma_t = eta * torch.sqrt(r1 * r2)
+    else:
+        sigma_t = torch.zeros_like(alpha_bar_t)
+    return torch.sqrt(alpha_bar_tm1) * x0_pred + torch.sqrt(1.0 - alpha_bar_tm1 - sigma_t**2) * pred_noise
+
+
+def dpmpp_2m(
+    x_t: torch.Tensor,
+    pred_x0: torch.Tensor,
+    t_index: int,
+    prev_x0: torch.Tensor | None = None,
+    prev_h: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, float]:
+    """DPM-Solver++(2M) multistep update in x0-prediction space.
+
+    Faithful port of `src/diffusion_params.dpmpp_2m` (upstream ea1b4ed). First
+    step is first-order DPM-Solver++; subsequent steps add the 2nd-order
+    multistep correction using the previous step's x0 and lambda-step `prev_h`.
+    Returns `(x_{t-1}, x0_t, h)`; carry `x0_t`/`h` into the next call.
+    """
+    t = int(INFERENCE_STEPS[t_index])
+    tm1 = int(INFERENCE_STEPS[t_index - 1])
+    alpha_bar_t = float(ALPHA_BAR[t])
+    alpha_bar_tm1 = float(ALPHA_BAR[tm1])
+
+    alpha_t = math.sqrt(alpha_bar_t)
+    alpha_tm1 = math.sqrt(alpha_bar_tm1)
+    sigma_t = math.sqrt(1.0 - alpha_bar_t)
+    sigma_tm1 = math.sqrt(1.0 - alpha_bar_tm1)
+
+    lambda_t = math.log(alpha_t + 1e-12) - math.log(sigma_t + 1e-12)
+    lambda_tm1 = math.log(alpha_tm1 + 1e-12) - math.log(sigma_tm1 + 1e-12)
+    h = lambda_tm1 - lambda_t
+
+    sample_coeff = sigma_tm1 / (sigma_t + 1e-12)
+    phi_1 = math.expm1(-h)
+
+    d0 = pred_x0
+    x_tm1 = sample_coeff * x_t - alpha_tm1 * phi_1 * d0
+
+    if prev_x0 is not None and prev_h is not None:
+        r = prev_h / (h + 1e-12)
+        d1 = (d0 - prev_x0) / (r + 1e-12)
+        x_tm1 = x_tm1 - 0.5 * alpha_tm1 * phi_1 * d1
+
+    return x_tm1, d0, h

--- a/src_torch/inference.py
+++ b/src_torch/inference.py
@@ -20,6 +20,7 @@ from .diffusion import (
     dpmpp_2m,
 )
 from .model import GFS_CHANNELS, HRRR_CHANNELS, HRRRCast
+from .profiling import profile_region
 
 # 138 diffusion-predicted channels (the HRRR analysis state).
 PREDICTED_CHANNELS = HRRR_CHANNELS
@@ -82,7 +83,7 @@ def diffusion_loop(
         raise ValueError(f"unknown sampler {sampler!r}; expected 'dpmpp' or 'ddim'")
     start = predicted_channels + gfs_channels
     prev_x0 = prev_h = None
-    with torch.no_grad():
+    with profile_region("torch.diffusion_loop", detail=True), torch.no_grad():
         for t_i in range(num_inference_steps - 1):
             ti = num_inference_steps - 1 - t_i
             t = int(INFERENCE_STEPS[ti])
@@ -132,15 +133,18 @@ def forecast_hour(
         xn: initial Gaussian noise for the predicted channels, NCHW `(B, C_pred, H, W)`.
         channel_mins/channel_maxs: per-channel normalized clip bounds.
     """
-    y = diffusion_loop(
-        model,
-        x_batch,
-        xn,
-        sampler=sampler,
-        predicted_channels=predicted_channels,
-        gfs_channels=gfs_channels,
-    )
-    mins = channel_mins[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
-    maxs = channel_maxs[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
-    y = torch.clip(y, mins, maxs)
-    return y.permute(0, 2, 3, 1).contiguous()
+    with profile_region("torch.forecast_hour", detail=True):
+        y = diffusion_loop(
+            model,
+            x_batch,
+            xn,
+            sampler=sampler,
+            predicted_channels=predicted_channels,
+            gfs_channels=gfs_channels,
+        )
+        with profile_region("torch.clip_output", detail=True):
+            mins = channel_mins[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
+            maxs = channel_maxs[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
+            y = torch.clip(y, mins, maxs)
+        with profile_region("torch.output_to_nhwc", detail=True):
+            return y.permute(0, 2, 3, 1).contiguous()

--- a/src_torch/inference.py
+++ b/src_torch/inference.py
@@ -1,0 +1,146 @@
+"""Core HRRRCast inference engine: model load, sampling loop, and one forecast hour.
+
+`diffusion_loop` is the single shared reverse-diffusion sampler; `forecast_hour`
+wraps it (diffusion -> clip -> normalized NHWC) and is the per-hour unit used by
+both the multi-hour `rollout` and the `validate` parity harness, so production
+and verification run identical numerics.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .config import DEFAULT_MODULE_STATE
+from .diffusion import (
+    INFERENCE_STEPS,
+    NUM_DIFFUSION_STEPS,
+    NUM_INFERENCE_STEPS,
+    compute_epsilon,
+    ddim,
+    dpmpp_2m,
+)
+from .model import GFS_CHANNELS, HRRR_CHANNELS, HRRRCast
+
+# 138 diffusion-predicted channels (the HRRR analysis state).
+PREDICTED_CHANNELS = HRRR_CHANNELS
+
+# Upstream ea1b4ed samples with DPM-Solver++(2M); "ddim" is kept for reference.
+DEFAULT_SAMPLER = "dpmpp"
+
+
+def load_hrrrcast(
+    state_path: str | None = None,
+    *,
+    device: torch.device | str | None = None,
+    compile_model: bool = False,
+    compile_mode: str = "default",
+) -> HRRRCast:
+    """Construct `HRRRCast` and load the module state dict for inference.
+
+    When `compile_model` is set, the module is wrapped with `torch.compile`
+    (Inductor), which fuses the elementwise/LayerNorm ops that dominate GPU
+    time and reduces kernel-launch overhead. The first forward call pays a
+    one-time compilation cost; subsequent same-shape calls run the fused graph.
+    """
+    device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    model = HRRRCast().to(device).eval()
+    state = torch.load(state_path or str(DEFAULT_MODULE_STATE), map_location=device, weights_only=True)
+    model.load_state_dict(state)
+    # Store conv weights in channels_last so cuDNN runs its NHWC tensor-core
+    # kernels on H100 without inserting per-conv NCHW<->NHWC transposes.
+    model = model.to(memory_format=torch.channels_last)
+    for param in model.parameters():
+        param.requires_grad_(False)
+    if compile_model:
+        model = torch.compile(model, mode=compile_mode)
+    return model
+
+
+def diffusion_loop(
+    model: HRRRCast,
+    x_batch: torch.Tensor,
+    xn: torch.Tensor,
+    *,
+    sampler: str = DEFAULT_SAMPLER,
+    predicted_channels: int = PREDICTED_CHANNELS,
+    gfs_channels: int = GFS_CHANNELS,
+    num_inference_steps: int = NUM_INFERENCE_STEPS,
+    num_diffusion_steps: int = NUM_DIFFUSION_STEPS,
+) -> torch.Tensor:
+    """Reverse-diffusion sampling loop for a stacked-member NCHW batch.
+
+    `sampler` selects the per-step update (all ops are elementwise, so the loop
+    stays in NCHW):
+      * ``"dpmpp"`` - DPM-Solver++(2M) in x0 space (upstream ea1b4ed default).
+      * ``"ddim"``  - first-order DDIM in epsilon space.
+
+    The noised channels of the model input are replaced by the running iterate
+    `xn` and the per-step time encoding each iteration. Returns the final `xn`
+    (NCHW); callers clip to physical bounds.
+    """
+    if sampler not in ("dpmpp", "ddim"):
+        raise ValueError(f"unknown sampler {sampler!r}; expected 'dpmpp' or 'ddim'")
+    start = predicted_channels + gfs_channels
+    prev_x0 = prev_h = None
+    with torch.no_grad():
+        for t_i in range(num_inference_steps - 1):
+            ti = num_inference_steps - 1 - t_i
+            t = int(INFERENCE_STEPS[ti])
+            step_encoding = torch.full(
+                (x_batch.shape[0], 1, x_batch.shape[2], x_batch.shape[3]),
+                t / num_diffusion_steps,
+                dtype=x_batch.dtype,
+                device=x_batch.device,
+            )
+            x_iter = torch.cat(
+                [
+                    x_batch[:, :start],
+                    xn,
+                    x_batch[:, start + predicted_channels : -2],
+                    step_encoding,
+                    x_batch[:, -1:],
+                ],
+                dim=1,
+            )
+            x0 = model(x_iter)
+            if sampler == "dpmpp":
+                xn, prev_x0, prev_h = dpmpp_2m(xn, x0, ti, prev_x0=prev_x0, prev_h=prev_h)
+            else:
+                epsilon = compute_epsilon(xn, x0, t)
+                xn = ddim(xn, epsilon, ti)
+    return xn
+
+
+def forecast_hour(
+    model: HRRRCast,
+    x_batch: torch.Tensor,
+    xn: torch.Tensor,
+    channel_mins: torch.Tensor,
+    channel_maxs: torch.Tensor,
+    *,
+    sampler: str = DEFAULT_SAMPLER,
+    predicted_channels: int = PREDICTED_CHANNELS,
+    gfs_channels: int = GFS_CHANNELS,
+) -> torch.Tensor:
+    """Run one forecast hour for a stacked-member batch.
+
+    inputs (assembled NCHW `x_batch` + initial noise `xn`) -> `diffusion_loop`
+    -> clip to physical channel bounds -> normalized NHWC `(B, H, W, C_pred)`.
+
+    Args:
+        x_batch: assembled model input, NCHW `(B, C_in, H, W)`.
+        xn: initial Gaussian noise for the predicted channels, NCHW `(B, C_pred, H, W)`.
+        channel_mins/channel_maxs: per-channel normalized clip bounds.
+    """
+    y = diffusion_loop(
+        model,
+        x_batch,
+        xn,
+        sampler=sampler,
+        predicted_channels=predicted_channels,
+        gfs_channels=gfs_channels,
+    )
+    mins = channel_mins[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
+    maxs = channel_maxs[:predicted_channels].to(device=y.device, dtype=y.dtype)[None, :, None, None]
+    y = torch.clip(y, mins, maxs)
+    return y.permute(0, 2, 3, 1).contiguous()

--- a/src_torch/inference.py
+++ b/src_torch/inference.py
@@ -24,7 +24,7 @@ from .model import GFS_CHANNELS, HRRR_CHANNELS, HRRRCast
 # 138 diffusion-predicted channels (the HRRR analysis state).
 PREDICTED_CHANNELS = HRRR_CHANNELS
 
-# Upstream ea1b4ed samples with DPM-Solver++(2M); "ddim" is kept for reference.
+# The TensorFlow inference path samples with DPM-Solver++(2M); "ddim" is kept for reference.
 DEFAULT_SAMPLER = "dpmpp"
 
 
@@ -71,7 +71,7 @@ def diffusion_loop(
 
     `sampler` selects the per-step update (all ops are elementwise, so the loop
     stays in NCHW):
-      * ``"dpmpp"`` - DPM-Solver++(2M) in x0 space (upstream ea1b4ed default).
+      * ``"dpmpp"`` - DPM-Solver++(2M) in x0 space (TensorFlow inference default).
       * ``"ddim"``  - first-order DDIM in epsilon space.
 
     The noised channels of the model input are replaced by the running iterate

--- a/src_torch/model.py
+++ b/src_torch/model.py
@@ -1,0 +1,188 @@
+"""Clean, declarative PyTorch-native HRRRCast inference model (NCHW).
+
+This module contains no dependency on the exported Keras architecture metadata
+(`static_architecture.py`). All shapes, block counts, and channel widths are
+declared explicitly in `HRRRCast.__init__`.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+HRRR_CHANNELS = 138
+GFS_CHANNELS = 42
+NOISED_CHANNELS = 138
+OTHER_CHANNELS = 10
+TIME_DIM = 256
+LN_EPS = 1.0e-6
+REFLECT_PAD_H = (3, 2)
+REFLECT_PAD_W = (1, 0)
+
+
+class ChannelLayerNorm(nn.Module):
+    """LayerNorm along the channel axis for NCHW (or feature axis for NC).
+
+    Equivalent to Keras `LayerNormalization(axis=[C])`.
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        *,
+        affine_scale: bool = True,
+        affine_center: bool = True,
+        eps: float = LN_EPS,
+    ):
+        super().__init__()
+        self.num_channels = num_channels
+        self.eps = eps
+        if affine_scale:
+            self.gamma = nn.Parameter(torch.ones(num_channels))
+        else:
+            self.register_parameter("gamma", None)
+        if affine_center:
+            self.beta = nn.Parameter(torch.zeros(num_channels))
+        else:
+            self.register_parameter("beta", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        mean = x.mean(dim=1, keepdim=True)
+        var = ((x - mean) ** 2).mean(dim=1, keepdim=True)
+        y = (x - mean) * torch.rsqrt(var + self.eps)
+        if x.ndim == 2:
+            if self.gamma is not None:
+                y = y * self.gamma
+            if self.beta is not None:
+                y = y + self.beta
+            return y
+        if self.gamma is not None:
+            y = y * self.gamma[None, :, None, None]
+        if self.beta is not None:
+            y = y + self.beta[None, :, None, None]
+        return y
+
+
+class ResidualBlock(nn.Module):
+    """One HRRRCast residual block: conv-LN-relu-conv-LN -> FiLM -> CBAM -> shortcut."""
+
+    def __init__(self, in_ch: int, out_ch: int, time_dim: int, cbam_reduce: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_ch, out_ch, kernel_size=3, padding=1, bias=False)
+        self.norm1 = ChannelLayerNorm(out_ch, affine_scale=False, affine_center=True)
+        self.conv2 = nn.Conv2d(out_ch, out_ch, kernel_size=3, padding=1, bias=False)
+        self.norm2 = ChannelLayerNorm(out_ch, affine_scale=True, affine_center=True)
+        self.film_gamma = nn.Linear(time_dim, out_ch)
+        self.film_beta = nn.Linear(time_dim, out_ch)
+        self.cbam_ch_mlp_1 = nn.Linear(out_ch, cbam_reduce)
+        self.cbam_ch_mlp_2 = nn.Linear(cbam_reduce, out_ch)
+        self.cbam_sp_conv7 = nn.Conv2d(1, 1, kernel_size=7, padding=3, bias=False)
+        if in_ch != out_ch:
+            self.shortcut = nn.Conv2d(in_ch, out_ch, kernel_size=1, bias=False)
+        else:
+            self.shortcut = None
+
+    def forward(self, x: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
+        y = F.relu(self.norm1(self.conv1(x)))
+        y = self.norm2(self.conv2(y))
+        y = y * self.film_gamma(time)[:, :, None, None] + self.film_beta(time)[:, :, None, None]
+        ch_pool = y.mean(dim=(2, 3))
+        ch_gate = torch.sigmoid(self.cbam_ch_mlp_2(F.relu(self.cbam_ch_mlp_1(ch_pool))))
+        y = y * ch_gate[:, :, None, None]
+        sp_gate = torch.sigmoid(self.cbam_sp_conv7(y.mean(dim=1, keepdim=True)))
+        y = y * sp_gate
+        skip = self.shortcut(x) if self.shortcut is not None else x
+        return F.relu(y + skip)
+
+
+class ResidualStack(nn.Module):
+    """A stack of `ResidualBlock`s with the first block doing any channel projection."""
+
+    def __init__(self, in_ch: int, out_ch: int, n_blocks: int, time_dim: int, cbam_reduce: int):
+        super().__init__()
+        blocks: list[nn.Module] = []
+        for i in range(n_blocks):
+            block_in = in_ch if i == 0 else out_ch
+            blocks.append(ResidualBlock(block_in, out_ch, time_dim, cbam_reduce))
+        self.blocks = nn.ModuleList(blocks)
+
+    def forward(self, x: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(x, time)
+        return x
+
+
+class HRRRCast(nn.Module):
+    """PyTorch-native HRRRCast diffusion denoiser in NCHW layout.
+
+    Accepts NCHW tensors of shape `(B, 328, H, W)` and returns `(B, 138, H, W)`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        processed_ch = 136 + 40 + 136 + OTHER_CHANNELS  # 322
+
+        self.time_dense = nn.Linear(2, TIME_DIM)
+        self.time_norm = ChannelLayerNorm(TIME_DIM)
+        self.skip1 = nn.Linear(TIME_DIM, TIME_DIM)
+        self.skip2 = nn.Linear(TIME_DIM, 1)
+
+        self.hrrr_pre = ResidualStack(HRRR_CHANNELS + OTHER_CHANNELS, 136, n_blocks=2, time_dim=TIME_DIM, cbam_reduce=17)
+        self.gfs_pre = ResidualStack(GFS_CHANNELS + OTHER_CHANNELS, 40, n_blocks=2, time_dim=TIME_DIM, cbam_reduce=20)
+        self.noised_pre = ResidualStack(NOISED_CHANNELS + OTHER_CHANNELS, 136, n_blocks=2, time_dim=TIME_DIM, cbam_reduce=17)
+
+        self.enc0 = ResidualStack(processed_ch, 288, n_blocks=2, time_dim=TIME_DIM, cbam_reduce=16)
+        self.enc1 = ResidualStack(288, 256, n_blocks=3, time_dim=TIME_DIM, cbam_reduce=16)
+        self.enc2 = ResidualStack(256, 256, n_blocks=4, time_dim=TIME_DIM, cbam_reduce=16)
+
+        self.processor = ResidualStack(256, 256, n_blocks=14, time_dim=TIME_DIM, cbam_reduce=16)
+
+        self.dec0 = ResidualStack(256 + 256, 256, n_blocks=4, time_dim=TIME_DIM, cbam_reduce=16)
+        self.dec1 = ResidualStack(256 + 288, 256, n_blocks=3, time_dim=TIME_DIM, cbam_reduce=16)
+        self.dec2 = ResidualStack(256 + processed_ch, 288, n_blocks=2, time_dim=TIME_DIM, cbam_reduce=16)
+
+        self.output_refine = ResidualStack(288, 288, n_blocks=1, time_dim=TIME_DIM, cbam_reduce=16)
+        self.output_conv = nn.Conv2d(288, HRRR_CHANNELS, kernel_size=3, padding=1, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # The saved Keras model uses tf.gather with negative indices for the
+        # time-condition input, which yields zeros rather than wrap-around.
+        time_input = torch.zeros((x.shape[0], 2), dtype=x.dtype, device=x.device)
+        time = F.relu(self.time_norm(self.time_dense(time_input)))
+
+        padded = F.pad(x, (REFLECT_PAD_W[0], REFLECT_PAD_W[1], REFLECT_PAD_H[0], REFLECT_PAD_H[1]), mode="reflect")
+        # Enter channels_last for the whole conv graph; cuDNN then uses NHWC
+        # tensor-core kernels directly (no per-conv layout transposes).
+        padded = padded.contiguous(memory_format=torch.channels_last)
+        hrrr = padded[:, :HRRR_CHANNELS]
+        gfs = padded[:, HRRR_CHANNELS:HRRR_CHANNELS + GFS_CHANNELS]
+        noised = padded[:, HRRR_CHANNELS + GFS_CHANNELS:HRRR_CHANNELS + GFS_CHANNELS + NOISED_CHANNELS]
+        other = padded[:, HRRR_CHANNELS + GFS_CHANNELS + NOISED_CHANNELS:]
+
+        hrrr_p = self.hrrr_pre(torch.cat([hrrr, other], dim=1), time)
+        gfs_p = self.gfs_pre(torch.cat([gfs, other], dim=1), time)
+        noised_p = self.noised_pre(torch.cat([noised, other], dim=1), time)
+        processed = torch.cat([hrrr_p, gfs_p, noised_p, other], dim=1)
+
+        e0 = self.enc0(processed, time)
+        p0 = F.max_pool2d(e0, kernel_size=2, stride=2)
+        e1 = self.enc1(p0, time)
+        p1 = F.max_pool2d(e1, kernel_size=2, stride=2)
+        e2 = self.enc2(p1, time)
+        p2 = F.max_pool2d(e2, kernel_size=2, stride=2)
+
+        bottleneck = self.processor(p2, time)
+
+        u0 = F.interpolate(bottleneck, scale_factor=2, mode="nearest")
+        d0 = self.dec0(torch.cat([u0, p1], dim=1), time)
+        u1 = F.interpolate(d0, scale_factor=2, mode="nearest")
+        d1 = self.dec1(torch.cat([u1, p0], dim=1), time)
+        u2 = F.interpolate(d1, scale_factor=2, mode="nearest")
+        d2 = self.dec2(torch.cat([u2, processed], dim=1), time)
+
+        refined = self.output_conv(self.output_refine(d2, time)).float()
+        skip_scale = torch.sigmoid(self.skip2(F.relu(self.skip1(time))))[:, :, None, None]
+        out = refined + (hrrr - noised) * skip_scale + noised
+        return out[:, :, REFLECT_PAD_H[0]:-REFLECT_PAD_H[1], REFLECT_PAD_W[0]:]

--- a/src_torch/output.py
+++ b/src_torch/output.py
@@ -1,0 +1,165 @@
+"""Per-hour HRRRCast NetCDF assembly and writing helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Mapping, Union
+
+import numpy as np
+import torch
+import xarray as xr
+
+from .variables import (
+    LEVELS,
+    PL_VARS,
+    SFC_VARS,
+    compute_diagnostics,
+    denormalize,
+    inverse_transforms_physical,
+)
+
+
+def create_dataset(
+    init_datetime: datetime,
+    hour: int,
+    lats: np.ndarray,
+    lons: np.ndarray,
+    data: np.ndarray,
+) -> xr.Dataset:
+    """Build an xarray dataset for a single (init_time, lead_time=hour) from a (H, W, C) array."""
+    data_vars: dict[str, xr.DataArray] = {}
+    var_index = 0
+    for var in PL_VARS:
+        pl_data = np.transpose(data[..., var_index : var_index + len(LEVELS)], (2, 0, 1))
+        data_vars[var] = xr.DataArray(
+            np.expand_dims(np.expand_dims(pl_data, 0), 0),
+            dims=("time", "lead_time", "level", "latitude", "longitude"),
+            coords={
+                "time": [init_datetime],
+                "lead_time": ("lead_time", [hour], {"units": "hours"}),
+                "level": ("level", LEVELS, {"units": "hPa"}),
+                "latitude": (("latitude", "longitude"), lats),
+                "longitude": (("latitude", "longitude"), lons),
+            },
+            name=var,
+        )
+        var_index += len(LEVELS)
+
+    for var in SFC_VARS:
+        data_vars[var] = xr.DataArray(
+            np.expand_dims(np.expand_dims(data[..., var_index], 0), 0),
+            dims=("time", "lead_time", "latitude", "longitude"),
+            coords={
+                "time": [init_datetime],
+                "lead_time": ("lead_time", [hour], {"units": "hours"}),
+                "latitude": (("latitude", "longitude"), lats),
+                "longitude": (("latitude", "longitude"), lons),
+            },
+            name=var,
+        )
+        var_index += 1
+    return xr.Dataset(data_vars)
+
+
+def add_static_fields(
+    ds: xr.Dataset,
+    static_arrays: Mapping[str, np.ndarray],
+    init_datetime: datetime,
+    hour: int,
+    lats: np.ndarray,
+    lons: np.ndarray,
+) -> xr.Dataset:
+    """Inject 2D constant fields (e.g. LAND, OROG) into the dataset for this hour."""
+    for name, values in static_arrays.items():
+        ds[name] = xr.DataArray(
+            np.asarray(values, dtype=np.float32)[None, None, :, :],
+            dims=("time", "lead_time", "latitude", "longitude"),
+            coords={
+                "time": [init_datetime],
+                "lead_time": ("lead_time", [hour], {"units": "hours"}),
+                "latitude": (("latitude", "longitude"), lats),
+                "longitude": (("latitude", "longitude"), lons),
+            },
+            name=name,
+        )
+    return ds
+
+
+def static_fields_from_npz(npz: np.lib.npyio.NpzFile) -> dict[str, np.ndarray]:
+    """Extract LAND/OROG-style constant fields from a preprocessed HRRR npz."""
+    out: dict[str, np.ndarray] = {}
+    for name in ("LAND", "OROG"):
+        key = f"{name}_raw"
+        if key in npz.files:
+            out[name] = np.asarray(npz[key], dtype=np.float32)
+    return out
+
+
+def normalized_to_physical(normalized: torch.Tensor) -> np.ndarray:
+    """Denormalize a (1, H, W, C) NHWC tensor and undo log transforms; returns numpy (H, W, C)."""
+    return inverse_transforms_physical(denormalize(normalized)).detach().cpu().numpy()[0]
+
+
+def write_hour(
+    *,
+    normalized: torch.Tensor,
+    hour: int,
+    static_fields: Mapping[str, np.ndarray],
+    init_datetime: datetime,
+    lats: np.ndarray,
+    lons: np.ndarray,
+    output_dir: Path,
+    member: Union[int, str],
+) -> Path:
+    """Build per-hour dataset, run diagnostics, and write `hrrrcast_mem{member}_f{hour:02d}.nc`."""
+    physical = normalized_to_physical(normalized)
+    ds = create_dataset(init_datetime, hour, lats, lons, physical)
+    ds = add_static_fields(ds, static_fields, init_datetime, hour, lats, lons)
+    ds = compute_diagnostics(ds)
+    # Upstream naming convention: per-member `m{NN}`, ensemble mean `avg`, spread `spr`.
+    mem_str = str(member) if str(member) in ("avg", "spr") else f"m{int(member):02d}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out = output_dir / f"hrrrcast_{mem_str}_f{hour:02d}.nc"
+    ds.to_netcdf(out)
+    ds.close()
+    return out
+
+
+def convert_netcdf_hours_to_grib2(
+    *,
+    init_time: str,
+    member: int | str,
+    hours: list[int],
+    in_dir: str | Path,
+    out_dir: str | Path,
+) -> list[Path]:
+    """Convert per-hour HRRRCast NetCDF files to GRIB2 via the model's `src/nc2grib.py`.
+
+    `nc2grib` (and its `grib2io`/`eccodes` deps) is imported lazily so importing
+    this module never requires the GRIB stack.
+    """
+    from .config import add_src_to_path
+
+    add_src_to_path()
+    from nc2grib import Netcdf2Grib  # type: ignore[import-not-found]
+
+    init_datetime = datetime.fromisoformat(init_time)
+    in_path = Path(in_dir)
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    converter = Netcdf2Grib()
+    written: list[Path] = []
+    for hour in hours:
+        mem_str = member if member in ("avg", "spr") else f"m{int(member):02d}"
+        nc_path = in_path / f"hrrrcast_{mem_str}_f{hour:02d}.nc"
+        ds = xr.open_dataset(nc_path, decode_timedelta=False)
+        out_file = out_path / f"hrrrcast.{mem_str}.t{init_datetime.hour:02d}z.pgrb2.f{hour:02d}"
+        try:
+            # Upstream nc2grib.save_grib2 takes the full output path; the
+            # member->filename mapping lives here in the caller.
+            converter.save_grib2(init_datetime, ds, str(out_file))
+            written.append(out_file)
+        finally:
+            ds.close()
+    return written

--- a/src_torch/profiling.py
+++ b/src_torch/profiling.py
@@ -1,0 +1,89 @@
+"""Optional benchmark/profiling helpers for HRRRCast inference.
+
+Instrumentation is disabled by default. Enable with:
+  HRRRCAST_PROFILE=1        # timing + CUDA sync + NVTX
+  HRRRCAST_PROFILE_TIMING=1 # timing logs only
+  HRRRCAST_NVTX=1           # NVTX ranges only
+  HRRRCAST_SYNC_TIMING=1    # synchronize CUDA around timed regions
+  HRRRCAST_PROFILE_DETAIL=1 # include nested per-forward/per-op regions
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+import torch
+
+
+_TRUE = {"1", "true", "TRUE", "yes", "YES", "on", "ON"}
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "") in _TRUE
+
+
+def timing_enabled() -> bool:
+    return _env_enabled("HRRRCAST_PROFILE") or _env_enabled("HRRRCAST_PROFILE_TIMING")
+
+
+def nvtx_enabled() -> bool:
+    return torch.cuda.is_available() and (_env_enabled("HRRRCAST_PROFILE") or _env_enabled("HRRRCAST_NVTX"))
+
+
+def sync_enabled() -> bool:
+    return torch.cuda.is_available() and (_env_enabled("HRRRCAST_PROFILE") or _env_enabled("HRRRCAST_SYNC_TIMING"))
+
+
+def detail_enabled() -> bool:
+    return _env_enabled("HRRRCAST_PROFILE_DETAIL")
+
+
+def synchronize_if_enabled() -> None:
+    if sync_enabled():
+        torch.cuda.synchronize()
+
+
+@dataclass
+class ProfileRecord:
+    elapsed: float = 0.0
+
+
+@contextmanager
+def profile_region(
+    name: str,
+    *,
+    logger: logging.Logger | None = None,
+    extra: str = "",
+    detail: bool = False,
+) -> Iterator[ProfileRecord]:
+    """Optionally time and/or NVTX-mark a source-code region."""
+    if detail and not detail_enabled():
+        yield ProfileRecord()
+        return
+
+    do_timing = timing_enabled()
+    do_nvtx = nvtx_enabled()
+    record = ProfileRecord()
+    if not (do_timing or do_nvtx or sync_enabled()):
+        yield record
+        return
+
+    synchronize_if_enabled()
+    if do_nvtx:
+        torch.cuda.nvtx.range_push(name)
+    t0 = time.perf_counter()
+    try:
+        yield record
+    finally:
+        synchronize_if_enabled()
+        record.elapsed = time.perf_counter() - t0
+        if do_nvtx:
+            torch.cuda.nvtx.range_pop()
+        if do_timing:
+            log = logger or logging.getLogger(__name__)
+            log.info("BENCH phase=%s%s seconds=%.6f", name, extra, record.elapsed)

--- a/src_torch/rollout.py
+++ b/src_torch/rollout.py
@@ -1,0 +1,298 @@
+"""Multi-member, multi-hour autoregressive HRRRCast rollout core.
+
+This module is the PyTorch equivalent of the autoregressive forecast loop
+inside `src/fcst.py::WeatherForecaster.autoregressive_rollout`. It contains
+only the tensor/numpy logic; per-hour I/O is delegated through a callback.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from datetime import datetime
+from typing import Callable, Iterable, Mapping
+
+import numpy as np
+import pandas as pd
+import torch
+
+from .inference import DEFAULT_SAMPLER, GFS_CHANNELS, PREDICTED_CHANNELS, forecast_hour
+from .model import HRRRCast
+
+
+logger = logging.getLogger(__name__)
+
+
+STATIC_CHANNELS = 2  # HRRR static (LAND/OROG) appended after predicted channels in the npz
+DATE_CHANNELS = 6
+STEP_CHANNELS = 1
+LEAD_CHANNELS = 1
+
+
+def _seed_from_pair(member: int, hour: int) -> int:
+    """Map TensorFlow-style stateless seed pair `[member, hour]` to a torch seed.
+
+    This does not reproduce TensorFlow's Philox stream bit-for-bit; it preserves
+    the same seed structure and deterministic member/hour independence.
+    """
+    return ((int(member) & 0xFFFFFFFF) << 32) ^ (int(hour) & 0xFFFFFFFF)
+
+
+def member_noise(
+    member: int,
+    shape: tuple[int, ...],
+    device: torch.device | str,
+    dtype: torch.dtype = torch.float32,
+    *,
+    hour: int = 0,
+) -> torch.Tensor:
+    """Deterministic Gaussian noise for a member/hour seed pair.
+
+    Uses a `torch.Generator` seeded from `[member, hour]`, matching the
+    TensorFlow code's stateless seed convention at the algorithm level. This is
+    NOT bit-identical to TensorFlow `stateless_normal`; exact pointwise
+    validation uses offline TF-dumped noise artifacts, not production forecast.
+    """
+    device_obj = torch.device(device)
+    generator = torch.Generator(device=device_obj).manual_seed(_seed_from_pair(member, hour))
+    return torch.randn(shape, generator=generator, dtype=dtype, device=device_obj)
+
+
+def advance_member_noise(
+    anchor_noise: torch.Tensor,
+    *,
+    member: int,
+    hour: int,
+    rho: float = 0.9,
+) -> torch.Tensor:
+    """Advance TF-style AR(1) member noise: rho * previous + sqrt(1-rho^2) * eps."""
+    sigma = math.sqrt(1.0 - rho * rho)
+    eps = member_noise(member, tuple(anchor_noise.shape), anchor_noise.device, anchor_noise.dtype, hour=hour)
+    return anchor_noise * rho + eps * sigma
+
+
+def phase_angles(num_members: int) -> dict[int, float]:
+    """Per-member phase angles used to phase-shift GFS forcing index.
+
+    Mirrors `src/fcst.py`: member 0 is always unshifted, even-sized
+    ensembles also keep member 1 unshifted, then add symmetric +/- offsets.
+    """
+    members = list(range(num_members))
+    half_count = num_members // 2 - ((num_members + 1) % 2)
+    step = 1.0 / half_count if half_count > 0 else 0.0
+    seq: list[float] = []
+    seq.append(0.0)
+    if num_members % 2 == 0:
+        seq.append(0.0)
+    for i in range(half_count):
+        seq.append(step * (i + 1))
+        seq.append(-step * (i + 1))
+    return {m: seq[i] for i, m in enumerate(members)}
+
+
+def compute_time_features(init_datetime: datetime, hour: int) -> np.ndarray:
+    """Cyclic hour-of-day + day-of-year features plus HRRR v3/v4 era masks. Returns (1, 6)."""
+    valid = pd.to_datetime([init_datetime]) + pd.to_timedelta([hour], unit="h")
+    h = pd.DatetimeIndex(valid).hour.astype(np.float32)
+    doy = pd.DatetimeIndex(valid).dayofyear.astype(np.float32)
+    v4 = (valid >= np.datetime64("2021-03-23T00")).astype(np.float32)
+    v3 = ((valid >= np.datetime64("2018-07-12T00")) & (valid < np.datetime64("2021-03-23T00"))).astype(np.float32)
+    return np.stack(
+        [
+            np.sin(2 * np.pi * h / 24.0),
+            np.cos(2 * np.pi * h / 24.0),
+            np.sin(2 * np.pi * doy / 365.0),
+            np.cos(2 * np.pi * doy / 365.0),
+            v4.astype(np.float32),
+            v3.astype(np.float32),
+        ],
+        axis=-1,
+    ).astype(np.float32)
+
+
+def date_encoding_field(init_datetime: datetime, hour: int, height: int, width: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    """Tile the (1, 6) date encoding across the spatial grid, return NCHW (1, 6, H, W)."""
+    feats = compute_time_features(init_datetime, hour)  # (1, 6)
+    t = torch.from_numpy(feats).to(device=device, dtype=dtype)
+    return t.view(1, 6, 1, 1).expand(1, 6, height, width).contiguous()
+
+
+def build_initial_input(
+    hrrr_npz: Mapping[str, np.ndarray],
+    gfs_model_input: np.ndarray,
+    *,
+    predicted_channels: int = PREDICTED_CHANNELS,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Build the initial (1, C, H, W) NCHW input tensor used as the starting state.
+
+    Channel layout (mirrors `src/fcst.py::main` for the diffusion path):
+      [predicted (138)] + [gfs (42)] + [noise placeholder (138)]
+      + [hrrr_static (2)] + [date (6)] + [step (1)] + [lead (1)]   = 328
+    """
+    device_obj = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    hrrr_input = np.asarray(hrrr_npz["model_input"], dtype=np.float32)
+    gfs_input = np.asarray(gfs_model_input, dtype=np.float32)
+    if hrrr_input.shape[0] != 1:
+        raise ValueError(f"Expected HRRR model_input with batch=1, got shape {hrrr_input.shape}")
+    nlat, nlon = hrrr_input.shape[1:3]
+    static_count = hrrr_input.shape[-1] - predicted_channels
+    if static_count < 0:
+        raise ValueError(f"HRRR model_input has only {hrrr_input.shape[-1]} channels; needs at least {predicted_channels}.")
+
+    noise_placeholder = np.ones((1, nlat, nlon, predicted_channels), dtype=np.float32)
+    date_channel = np.ones((1, nlat, nlon, DATE_CHANNELS), dtype=np.float32)
+    step_channel = np.ones((1, nlat, nlon, STEP_CHANNELS), dtype=np.float32)
+    lead_channel = np.ones((1, nlat, nlon, LEAD_CHANNELS), dtype=np.float32)
+
+    nhwc = np.concatenate(
+        [
+            hrrr_input[:, :, :, :predicted_channels],
+            gfs_input[0:1, :, :, :],
+            noise_placeholder,
+            hrrr_input[:, :, :, predicted_channels:],
+            date_channel,
+            step_channel,
+            lead_channel,
+        ],
+        axis=-1,
+    )
+    return torch.from_numpy(nhwc).permute(0, 3, 1, 2).contiguous().to(device=device_obj, dtype=dtype)
+
+
+# Type alias for the per-hour callback. Receives normalized NHWC tensor (1, H, W, C_out).
+HourCallback = Callable[[int, int, torch.Tensor], None]
+
+
+def autoregressive_rollout(
+    model: HRRRCast,
+    *,
+    init_input: torch.Tensor,
+    gfs_forcing: torch.Tensor,
+    members: list[int],
+    num_members: int,
+    lead_hours: int,
+    init_datetime: datetime,
+    channel_mins: torch.Tensor,
+    channel_maxs: torch.Tensor,
+    batch_size: int = 1,
+    on_hour: HourCallback,
+    predicted_channels: int = PREDICTED_CHANNELS,
+    gfs_channels: int = GFS_CHANNELS,
+    sampler: str = DEFAULT_SAMPLER,
+    noise_rho: float = 0.9,
+) -> None:
+    """Run the multi-member, multi-hour HRRRCast rollout.
+
+    Args:
+        init_input: (1, C, H, W) NCHW initial model input (from `build_initial_input`).
+        gfs_forcing: (N_fcst, C_gfs, H, W) NCHW GFS forcing block.
+        members: list of integer member ids to forecast (sorted, deduplicated upstream).
+        num_members: total ensemble size (used for symmetric phase shift weighting).
+        lead_hours: max forecast lead time in hours (inclusive).
+        on_hour: callback invoked once per (hour, member) with a normalized NHWC tensor.
+            Called for hour=0 (initial state) before the loop, and once per forecast hour.
+        noise_rho: AR(1) noise correlation coefficient, matching `src/fcst.py`.
+    """
+    device = init_input.device
+    dtype = init_input.dtype
+    height, width = init_input.shape[2], init_input.shape[3]
+
+    on_hour(0, members[0] if members else 0, _state_to_nhwc(init_input[:, :predicted_channels]))
+    # f00 is the same for every member (no diffusion yet); broadcast to remaining members.
+    f00_state = init_input[:, :predicted_channels]
+    for member in members[1:]:
+        on_hour(0, member, _state_to_nhwc(f00_state))
+
+    state_from_hour: dict[int, torch.Tensor] = {m: f00_state.clone() for m in members}
+    noise_state: dict[int, torch.Tensor] = {
+        m: member_noise(m, (1, predicted_channels, height, width), device=device, dtype=dtype, hour=0)
+        for m in members
+    }
+    start_pred_noise = predicted_channels + gfs_channels
+    phase_lookup = phase_angles(num_members)
+    forcing_count = gfs_forcing.shape[0]
+
+    for hour in range(1, lead_hours + 1):
+        from_hour = ((hour - 1) // 6) * 6
+        step = hour - from_hour
+
+        date_enc = date_encoding_field(init_datetime, hour, height, width, dtype=dtype, device=device)
+        lead_enc = torch.full((1, LEAD_CHANNELS, height, width), step / 6.0, dtype=dtype, device=device)
+
+        # Static/noise placeholder + date + (step placeholder) + lead. The step
+        # placeholder is overwritten inside the DDIM loop, so we just reuse the
+        # existing slice of init_input for it.
+        x_base = torch.cat(
+            [
+                init_input[:, start_pred_noise:-8],
+                date_enc,
+                init_input[:, -2:-1],
+                lead_enc,
+            ],
+            dim=1,
+        )
+
+        for batch_start in range(0, len(members), batch_size):
+            batch_members = members[batch_start : batch_start + batch_size]
+
+            x_members = []
+            xn_members = []
+            for member in batch_members:
+                phase_width = from_hour // 12
+                phase_shift = round(phase_width * phase_lookup[member])
+                forcing_idx = int(np.clip(hour - 1 + phase_shift, 0, forcing_count - 1))
+                x_member = torch.cat(
+                    [
+                        state_from_hour[member],
+                        gfs_forcing[forcing_idx : forcing_idx + 1],
+                        x_base,
+                    ],
+                    dim=1,
+                )
+                x_members.append(x_member)
+                xn = advance_member_noise(noise_state[member], member=member, hour=hour, rho=noise_rho)
+                noise_state[member] = xn
+                xn_members.append(xn)
+            x_batch = torch.cat(x_members, dim=0)
+            xn = torch.cat(xn_members, dim=0)
+
+            t0 = time.time()
+            y_nhwc = forecast_hour(
+                model,
+                x_batch,
+                xn,
+                channel_mins,
+                channel_maxs,
+                sampler=sampler,
+                predicted_channels=predicted_channels,
+                gfs_channels=gfs_channels,
+            )
+            elapsed = time.time() - t0
+            logger.info(
+                "hour=%d batch=%s/%s (members %s) predict %.3fs",
+                hour,
+                batch_start // batch_size + 1,
+                (len(members) + batch_size - 1) // batch_size,
+                batch_members,
+                elapsed,
+            )
+
+            for batch_idx, member in enumerate(batch_members):
+                y_member = y_nhwc[batch_idx : batch_idx + 1]  # NHWC (1, H, W, C)
+                if hour % 6 == 0:
+                    state_from_hour[member] = y_member.permute(0, 3, 1, 2).contiguous()
+                on_hour(hour, member, y_member)
+
+
+def _state_to_nhwc(t: torch.Tensor) -> torch.Tensor:
+    return t.permute(0, 2, 3, 1).contiguous()
+
+
+def gfs_forcing_to_nchw(gfs_model_input: np.ndarray, *, device: torch.device | str | None = None, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+    """Convert the GFS preprocessed forcing block to (N_fcst, C, H, W) NCHW."""
+    device_obj = torch.device(device or "cpu")
+    arr = np.asarray(gfs_model_input, dtype=np.float32)
+    return torch.from_numpy(arr).permute(0, 3, 1, 2).contiguous().to(device=device_obj, dtype=dtype)

--- a/src_torch/rollout.py
+++ b/src_torch/rollout.py
@@ -19,6 +19,7 @@ import torch
 
 from .inference import DEFAULT_SAMPLER, GFS_CHANNELS, PREDICTED_CHANNELS, forecast_hour
 from .model import HRRRCast
+from .profiling import profile_region
 
 
 logger = logging.getLogger(__name__)
@@ -260,17 +261,22 @@ def autoregressive_rollout(
             xn = torch.cat(xn_members, dim=0)
 
             t0 = time.time()
-            y_nhwc = forecast_hour(
-                model,
-                x_batch,
-                xn,
-                channel_mins,
-                channel_maxs,
-                sampler=sampler,
-                predicted_channels=predicted_channels,
-                gfs_channels=gfs_channels,
-            )
-            elapsed = time.time() - t0
+            with profile_region(
+                "torch.predict",
+                logger=logger,
+                extra=f" hour={hour} batch={batch_start // batch_size + 1} members={batch_members}",
+            ) as profile:
+                y_nhwc = forecast_hour(
+                    model,
+                    x_batch,
+                    xn,
+                    channel_mins,
+                    channel_maxs,
+                    sampler=sampler,
+                    predicted_channels=predicted_channels,
+                    gfs_channels=gfs_channels,
+                )
+            elapsed = profile.elapsed or (time.time() - t0)
             logger.info(
                 "hour=%d batch=%s/%s (members %s) predict %.3fs",
                 hour,

--- a/src_torch/rollout.py
+++ b/src_torch/rollout.py
@@ -189,7 +189,7 @@ def autoregressive_rollout(
     Args:
         init_input: (1, C, H, W) NCHW initial model input (from `build_initial_input`).
         gfs_forcing: (N_fcst, C_gfs, H, W) NCHW GFS forcing block.
-        members: list of integer member ids to forecast (sorted, deduplicated upstream).
+        members: list of integer member ids to forecast (sorted and deduplicated by the caller).
         num_members: total ensemble size (used for symmetric phase shift weighting).
         lead_hours: max forecast lead time in hours (inclusive).
         on_hour: callback invoked once per (hour, member) with a normalized NHWC tensor.

--- a/src_torch/validate.py
+++ b/src_torch/validate.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Parity harness: validate the PyTorch port against a TensorFlow reference dump.
+
+Runs the two checks that gate the port and asserts both stay within acceptance
+thresholds (normalized space):
+
+  1. First model forward : ``HRRRCast(first_model_input)`` vs ``first_model_output``
+  2. dpmpp-2m loop (f01)  : ``inference.forecast_hour`` vs ``final_normalized_f01``
+
+Both checks exercise the production code path (`inference.load_hrrrcast` and the
+shared `inference.forecast_hour` / `inference.diffusion_loop`), so a pass
+certifies the same functions the CLI runs. No production I/O.
+
+Usage:
+    python -m src_torch.validate [--dump REF.npz] [--state STATE.pt] [--out report.json]
+    python -m src_torch.cli validate ...        # equivalent
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import sys
+
+import numpy as np
+import torch
+
+from .config import DEFAULT_TENSOR_DUMP
+from .inference import forecast_hour, load_hrrrcast
+from .rollout import (
+    build_initial_input,
+    date_encoding_field,
+    gfs_forcing_to_nchw,
+    phase_angles,
+)
+from .variables import channel_bounds
+
+# Acceptance thresholds (normalized space) for the frozen reference case.
+FIRST_FORWARD_LIMITS = {"mean_abs": 2.0e-4, "rmse": 5.0e-4, "max_abs": 5.0e-2}
+DIFFUSION_LOOP_LIMITS = {"mean_abs": 1.0e-3, "rmse": 2.0e-3, "p99_abs": 5.0e-3}
+ROLLOUT_REPLAY_LIMITS = {"mean_abs": 1.5e-3, "rmse": 3.0e-3, "p99_abs": 1.0e-2}
+
+
+def _metrics(diff: torch.Tensor) -> dict:
+    ad = diff.abs()
+    flat = ad.flatten()
+    stride = max(flat.numel() // 5_000_000, 1)
+    return {
+        "max_abs": float(ad.max().item()),
+        "mean_abs": float(ad.mean().item()),
+        "rmse": float(torch.sqrt(torch.mean(diff * diff)).item()),
+        "p99_abs": float(torch.quantile(flat[::stride], 0.99).item()),
+    }
+
+
+def _check(name: str, metrics: dict, limits: dict, failures: list[str]) -> None:
+    for key, limit in limits.items():
+        if metrics[key] > limit:
+            failures.append(f"{name} {key} too high: {metrics[key]:.3e} > {limit:.1e}")
+
+
+def _data_files(base_dir: Path, init_time: str) -> tuple[Path, Path]:
+    date, hour = init_time.split("T")
+    yyyymmdd = date.replace("-", "")
+    cycle = base_dir / yyyymmdd / hour
+    return cycle / f"hrrr_{yyyymmdd}_{hour}.npz", cycle / f"gfs_{yyyymmdd}_{hour}.npz"
+
+
+def _load_tf_noise(path: Path, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    dump = np.load(path)
+    key = "noise" if "noise" in dump.files else "member_noise"
+    if key not in dump.files:
+        raise ValueError(f"{path} has no 'noise' or 'member_noise' array")
+    return torch.from_numpy(dump[key]).permute(0, 3, 1, 2).contiguous().to(device=device, dtype=dtype)
+
+
+def run_rollout_replay(
+    *,
+    rollout_dump: str,
+    state: str | None = None,
+    device: str | None = None,
+    sampler: str = "dpmpp",
+    base_dir: str | None = None,
+    init_time: str = "2024-05-06T23",
+    lead_hours: int = 6,
+    member: int = 0,
+) -> dict:
+    """Replay a TF rollout dump using TF per-hour noise and compare normalized outputs.
+
+    This is a validation-only parity harness. It intentionally lives outside the
+    production forecast CLI: production forecasts use native PyTorch AR(1) noise,
+    while this path replays TF-dumped `tf_noise_mNN_fHH.npz` tensors to isolate
+    cross-framework numerical differences.
+    """
+    dev = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    dump_dir = Path(rollout_dump)
+    data_root = Path(base_dir or os.environ.get("HRRRCAST_DATA", Path(__file__).resolve().parents[1] / "data"))
+    hrrr_path, gfs_path = _data_files(data_root, init_time)
+    hrrr_npz = np.load(hrrr_path)
+    gfs_model_input = np.asarray(np.load(gfs_path)["model_input"])
+
+    model = load_hrrrcast(state, device=dev)
+    init_input = build_initial_input(hrrr_npz, gfs_model_input, device=dev)
+    gfs_forcing = gfs_forcing_to_nchw(gfs_model_input, device=dev)
+    mins, maxs = channel_bounds(device=dev)
+
+    init_datetime = datetime.fromisoformat(str(hrrr_npz["init_datetime"]))
+    predicted_channels = init_input[:, :138].shape[1]
+    gfs_channels = gfs_forcing.shape[1]
+    height, width = init_input.shape[2], init_input.shape[3]
+    dtype = init_input.dtype
+    start_pred_noise = predicted_channels + gfs_channels
+    phase_lookup = phase_angles(member + 1)
+    forcing_count = gfs_forcing.shape[0]
+
+    state_from_hour = init_input[:, :predicted_channels].clone()
+    report: dict = {
+        "dump": str(dump_dir),
+        "base_dir": str(data_root),
+        "init_time": init_time,
+        "lead_hours": lead_hours,
+        "member": member,
+        "sampler": sampler,
+        "device": str(dev),
+        "hours": {},
+    }
+
+    failures: list[str] = []
+
+    def compare_hour(hour: int, y_nhwc: torch.Tensor) -> None:
+        target_path = dump_dir / f"tf_norm_m{member:02d}_f{hour:02d}.npz"
+        if not target_path.exists():
+            return
+        target = torch.from_numpy(np.load(target_path)["normalized"]).to(device=dev, dtype=y_nhwc.dtype)
+        m = _metrics(y_nhwc - target)
+        report["hours"][f"f{hour:02d}"] = m
+        _check(f"rollout_replay_f{hour:02d}", m, ROLLOUT_REPLAY_LIMITS, failures)
+
+    compare_hour(0, state_from_hour.permute(0, 2, 3, 1).contiguous())
+
+    for hour in range(1, lead_hours + 1):
+        from_hour = ((hour - 1) // 6) * 6
+        step = hour - from_hour
+        date_enc = date_encoding_field(init_datetime, hour, height, width, dtype=dtype, device=dev)
+        lead_enc = torch.full((1, 1, height, width), step / 6.0, dtype=dtype, device=dev)
+        x_base = torch.cat([init_input[:, start_pred_noise:-8], date_enc, init_input[:, -2:-1], lead_enc], dim=1)
+
+        phase_width = from_hour // 12
+        phase_shift = round(phase_width * phase_lookup[member])
+        forcing_idx = int(np.clip(hour - 1 + phase_shift, 0, forcing_count - 1))
+        x_member = torch.cat(
+            [
+                state_from_hour,
+                gfs_forcing[forcing_idx : forcing_idx + 1],
+                x_base,
+            ],
+            dim=1,
+        )
+        noise_path = dump_dir / f"tf_noise_m{member:02d}_f{hour:02d}.npz"
+        if not noise_path.exists():
+            raise FileNotFoundError(noise_path)
+        xn = _load_tf_noise(noise_path, device=dev, dtype=dtype)
+        y_nhwc = forecast_hour(model, x_member, xn, mins, maxs, sampler=sampler)
+        if hour % 6 == 0:
+            state_from_hour = y_nhwc.permute(0, 3, 1, 2).contiguous()
+        compare_hour(hour, y_nhwc)
+
+    report["status"] = "fail" if failures else "pass"
+    report["failures"] = failures
+    return report
+
+
+def run(
+    *,
+    dump: str = str(DEFAULT_TENSOR_DUMP),
+    state: str | None = None,
+    device: str | None = None,
+    sampler: str = "dpmpp",
+    out: str | None = None,
+    rollout_dump: str | None = None,
+    base_dir: str | None = None,
+    init_time: str = "2024-05-06T23",
+    lead_hours: int = 6,
+    member: int = 0,
+) -> tuple[dict, bool]:
+    """Run both parity checks; return (report, ok)."""
+    dev = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    tensors = np.load(dump)
+    model = load_hrrrcast(state, device=dev)
+
+    failures: list[str] = []
+    report: dict = {"device": str(dev), "dump": str(dump), "sampler": sampler}
+
+    # 1. first model forward
+    x = torch.from_numpy(tensors["first_model_input"]).permute(0, 3, 1, 2).contiguous().to(dev)
+    ff_target = torch.from_numpy(tensors["first_model_output"]).to(dev)
+    with torch.no_grad():
+        ff = model(x).permute(0, 2, 3, 1).contiguous()
+    report["first_forward"] = _metrics(ff - ff_target)
+    _check("first_forward", report["first_forward"], FIRST_FORWARD_LIMITS, failures)
+
+    # 2. diffusion loop (f01) via the shared production per-hour function
+    x_batch = torch.from_numpy(tensors["x_batch"]).permute(0, 3, 1, 2).contiguous().to(dev)
+    xn = torch.from_numpy(tensors["member_noise"]).permute(0, 3, 1, 2).contiguous().to(dev)
+    loop_target = torch.from_numpy(tensors["final_normalized_f01"]).to(dev)
+    mins, maxs = channel_bounds(device=dev)
+    out_nhwc = forecast_hour(model, x_batch, xn, mins, maxs, sampler=sampler)
+    report["diffusion_loop"] = _metrics(out_nhwc - loop_target)
+    _check("diffusion_loop", report["diffusion_loop"], DIFFUSION_LOOP_LIMITS, failures)
+
+    if rollout_dump:
+        replay_report = run_rollout_replay(
+            rollout_dump=rollout_dump,
+            state=state,
+            device=str(dev),
+            sampler=sampler,
+            base_dir=base_dir,
+            init_time=init_time,
+            lead_hours=lead_hours,
+            member=member,
+        )
+        report["rollout_replay"] = replay_report
+        failures.extend(f"rollout_replay {f}" for f in replay_report.get("failures", []))
+
+    report["status"] = "fail" if failures else "pass"
+    report["failures"] = failures
+    if out:
+        from pathlib import Path
+
+        Path(out).parent.mkdir(parents=True, exist_ok=True)
+        Path(out).write_text(json.dumps(report, indent=2) + "\n")
+    return report, not failures
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Validate PyTorch HRRRCast against a TF reference dump.")
+    ap.add_argument("--dump", default=str(DEFAULT_TENSOR_DUMP))
+    ap.add_argument("--state", default=None, help="Override module state dict path")
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    ap.add_argument("--sampler", default="dpmpp", choices=["dpmpp", "ddim"])
+    ap.add_argument("--rollout-dump", default=None, help="TF rollout dump directory with tf_noise_*.npz and tf_norm_*.npz for validation-only replay")
+    ap.add_argument("--base-dir", default=None, help="Data root containing preprocessed HRRR/GFS npz files (defaults to $HRRRCAST_DATA or repo/data)")
+    ap.add_argument("--init-time", default="2024-05-06T23")
+    ap.add_argument("--lead-hours", type=int, default=6)
+    ap.add_argument("--member", type=int, default=0)
+    ap.add_argument("--out", default=None, help="Optional path to write the JSON report")
+    args = ap.parse_args()
+
+    report, ok = run(
+        dump=args.dump,
+        state=args.state,
+        device=args.device,
+        sampler=args.sampler,
+        out=args.out,
+        rollout_dump=args.rollout_dump,
+        base_dir=args.base_dir,
+        init_time=args.init_time,
+        lead_hours=args.lead_hours,
+        member=args.member,
+    )
+    print(json.dumps(report, indent=2))
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src_torch/variables.py
+++ b/src_torch/variables.py
@@ -1,0 +1,205 @@
+"""Channel layout, normalization stats, inverse transforms, and the diagnostics bridge."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import h5py
+import numpy as np
+import torch
+
+from .config import REPO_ROOT
+
+# Per-channel normalization statistics shipped with the model. Override with
+# the HRRRCAST_NORM_FILE environment variable; defaults to the repo copy.
+DEFAULT_NORM_FILE = Path(
+    os.environ.get("HRRRCAST_NORM_FILE", REPO_ROOT / "net-diffusion" / "normalize-stats.nc")
+)
+
+
+PL_VARS = ["UGRD", "VGRD", "VVEL", "TMP", "HGT", "SPFH"]
+SFC_VARS = [
+    "PRES",
+    "MSLMA",
+    "REFC",
+    "T2M",
+    "UGRD10M",
+    "VGRD10M",
+    "UGRD80M",
+    "VGRD80M",
+    "D2M",
+    "TCDC",
+    "LCDC",
+    "MCDC",
+    "HCDC",
+    "VIS",
+    "APCP",
+    "HGTCC",
+    "CAPE",
+    "CIN",
+]
+LEVELS = [200, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 825, 850, 875, 900, 925, 950, 975, 1000]
+LOG_TRANSFORM_VARS = {"VIS", "APCP", "HGTCC", "CAPE"}
+NEG_LOG_TRANSFORM_VARS = {"CIN"}
+RAW_BOUNDS = {
+    "UGRD": (-120, 120),
+    "VGRD": (-120, 120),
+    "VVEL": (-30, 30),
+    "TMP": (180, 340),
+    "HGT": (-600, 20000),
+    "SPFH": (0, 0.05),
+    "PRES": (50000, 110000),
+    "MSLMA": (50000, 110000),
+    "REFC": (0, 80),
+    "T2M": (180, 340),
+    "UGRD10M": (-100, 100),
+    "VGRD10M": (-100, 100),
+    "UGRD80M": (-100, 100),
+    "VGRD80M": (-100, 100),
+    "D2M": (180, 340),
+    "TCDC": (0, 100),
+    "LCDC": (0, 100),
+    "MCDC": (0, 100),
+    "HCDC": (0, 100),
+    "VIS": (0, 100000),
+    "APCP": (0, 500),
+    "HGTCC": (0, 20000),
+    "CAPE": (0, 7000),
+    "CIN": (-2000, 0),
+}
+
+
+def _fallback_bounds() -> tuple[np.ndarray, np.ndarray]:
+    mins = []
+    maxs = []
+    for i, var in enumerate(RAW_BOUNDS):
+        vmin, vmax = RAW_BOUNDS[var]
+        if var in LOG_TRANSFORM_VARS:
+            vmin = np.log1p(vmin)
+            vmax = np.log1p(vmax)
+        elif var in NEG_LOG_TRANSFORM_VARS:
+            vmin = np.sign(vmin) * np.log1p(abs(vmin))
+            vmax = np.sign(vmax) * np.log1p(abs(vmax))
+        count = len(LEVELS) if i < len(PL_VARS) else 1
+        mins.extend([vmin] * count)
+        maxs.extend([vmax] * count)
+    return np.asarray(mins, dtype=np.float32), np.asarray(maxs, dtype=np.float32)
+
+
+def channel_bounds(
+    norm_file: str | Path = DEFAULT_NORM_FILE,
+    *,
+    device: torch.device | str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    means, stds, raw_mins, raw_maxs = read_channel_stats(norm_file)
+    mins = (raw_mins - means) / stds
+    maxs = (raw_maxs - means) / stds
+    return torch.from_numpy(mins).to(device=device), torch.from_numpy(maxs).to(device=device)
+
+
+def channel_mean_std(
+    norm_file: str | Path = DEFAULT_NORM_FILE,
+    *,
+    device: torch.device | str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    means, stds, _raw_mins, _raw_maxs = read_channel_stats(norm_file)
+    return torch.from_numpy(means).to(device=device), torch.from_numpy(stds).to(device=device)
+
+
+def read_channel_stats(
+    norm_file: str | Path = DEFAULT_NORM_FILE,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    fallback_mins, fallback_maxs = _fallback_bounds()
+    raw_means = []
+    raw_stds = []
+    raw_mins = []
+    raw_maxs = []
+    channel_idx = 0
+    with h5py.File(norm_file, "r") as h5:
+        for var in PL_VARS:
+            stats = np.asarray(h5[var])
+            nlev_stats = stats.shape[1] if stats.ndim > 1 else 1
+            for i, _level in enumerate(LEVELS):
+                if i < nlev_stats and stats.shape[0] >= 2:
+                    mean = float(stats[0, i])
+                    std = float(stats[1, i]) or 1.0
+                    vmin = float(stats[2, i]) if stats.shape[0] > 2 else float(fallback_mins[channel_idx])
+                    vmax = float(stats[3, i]) if stats.shape[0] > 3 else float(fallback_maxs[channel_idx])
+                    if np.isnan(vmin):
+                        vmin = float(fallback_mins[channel_idx])
+                    if np.isnan(vmax):
+                        vmax = float(fallback_maxs[channel_idx])
+                else:
+                    mean = 0.0
+                    std = 1.0
+                    vmin = float(fallback_mins[channel_idx])
+                    vmax = float(fallback_maxs[channel_idx])
+                raw_means.append(mean)
+                raw_stds.append(std)
+                raw_mins.append(vmin)
+                raw_maxs.append(vmax)
+                channel_idx += 1
+
+        for var in SFC_VARS:
+            stats = np.asarray(h5[var])
+            if stats.shape[0] >= 2:
+                mean = float(np.nanmean(stats[0]))
+                std = float(np.nanmean(stats[1])) or 1.0
+                vmin = float(np.nanmean(stats[2])) if stats.shape[0] > 2 else float(fallback_mins[channel_idx])
+                vmax = float(np.nanmean(stats[3])) if stats.shape[0] > 3 else float(fallback_maxs[channel_idx])
+                if np.isnan(vmin):
+                    vmin = float(fallback_mins[channel_idx])
+                if np.isnan(vmax):
+                    vmax = float(fallback_maxs[channel_idx])
+            else:
+                mean = 0.0
+                std = 1.0
+                vmin = float(fallback_mins[channel_idx])
+                vmax = float(fallback_maxs[channel_idx])
+            raw_means.append(mean)
+            raw_stds.append(std)
+            raw_mins.append(vmin)
+            raw_maxs.append(vmax)
+            channel_idx += 1
+
+    return (
+        np.asarray(raw_means, dtype=np.float32),
+        np.asarray(raw_stds, dtype=np.float32),
+        np.asarray(raw_mins, dtype=np.float32),
+        np.asarray(raw_maxs, dtype=np.float32),
+    )
+
+
+def denormalize(output: torch.Tensor) -> torch.Tensor:
+    means, stds = channel_mean_std(device=output.device)
+    return output * stds[: output.shape[-1]] + means[: output.shape[-1]]
+
+
+def inverse_transforms_physical(output: torch.Tensor) -> torch.Tensor:
+    result = output.clone()
+    offset = len(PL_VARS) * len(LEVELS)
+    for name in LOG_TRANSFORM_VARS:
+        idx = SFC_VARS.index(name)
+        channel = offset + idx
+        result[..., channel] = torch.expm1(result[..., channel])
+    for name in NEG_LOG_TRANSFORM_VARS:
+        idx = SFC_VARS.index(name)
+        channel = offset + idx
+        value = result[..., channel]
+        result[..., channel] = torch.sign(value) * torch.expm1(torch.abs(value))
+    return result
+
+
+def compute_diagnostics(ds):
+    """Add HRRRCast diagnostic variables, delegating to the model's `src/diagnostics.py`.
+
+    Imported lazily so merely importing this module does not pull the `src/`
+    post-processing dependencies (xarray, etc.).
+    """
+    from .config import add_src_to_path
+
+    add_src_to_path()
+    from diagnostics import compute_diagnostics as _impl  # type: ignore[import-not-found]
+
+    return _impl(ds)


### PR DESCRIPTION
## Summary

This MR adds a PyTorch-native implementation of the HRRRCast **inference** path under `src_torch/`. The existing TensorFlow code under `src/` is unchanged.

## `src_torch/` Layout

- `config.py`: repo-relative paths and bridge imports for shared `src/` utilities.
- `variables.py`: channel metadata, normalization, denormalization, and diagnostics bridge.
- `model.py`: PyTorch `HRRRCast(nn.Module)` matching the deployed Keras denoiser.
- `diffusion.py`: cosine schedule plus DDIM and DPM-Solver++(2M) updates.
- `inference.py`: model loading, optional `torch.compile`, and one-hour `forecast_hour()`.
- `rollout.py`: autoregressive multi-hour rollout, GFS phase shift, 6-hour reset, and AR(1) member noise.
- `output.py`: NetCDF assembly, diagnostics, and GRIB2 conversion bridge.
- `convert.py`: Keras archive to PyTorch `state_dict` converter with full key/shape validation.
- `validate.py`: TensorFlow parity checks, including optional rollout replay from TF dumps.
- `cli.py`: user-facing `forecast` / `validate` entry point.

## Weight Conversion

Generate PyTorch weights from the committed Keras archive after Git LFS has materialized `net-diffusion/model.keras`:

```bash
python -m src_torch.convert \
  --keras net-diffusion/model.keras \
  --out "${HRRRCAST_ARTIFACTS:-artifacts}/model_export/hrrrcast_module_state_dict.pt"
```

The converter reads `config.json` and `model.weights.h5` directly from the `.keras` archive and asserts full key/shape coverage against `HRRRCast.state_dict()`.

## Numerical Fidelity

Reference case: `2024-05-06T23`, member `0`, 25-step DPM-Solver++(2M).

| Stage | Metric | Result |
| --- | --- | --- |
| First model forward (normalized) | mean_abs / rmse | `1.14e-4` / `2.15e-4` |
| f01 diffusion loop with matched input noise (normalized) | mean_abs / rmse | `6.34e-4` / `1.19e-3` |
| f06 rollout with matched input noise (normalized) | mean_abs / rmse / p99 | `8.46e-4` / `1.76e-3` / `4.97e-3` |
| f00 analysis state | normalized error | exactly `0` |

Matched-noise comparisons replay the same per-hour diffusion noise in both frameworks to isolate implementation differences. Production PyTorch forecasts use native PyTorch AR(1) noise with the same distribution and temporal correlation as TensorFlow; ensemble/distribution validation should be assessed separately with model-owner metrics.

### Noise Generator Difference

TensorFlow uses `tf.random.stateless_normal(seed=[member, hour])`, while PyTorch uses its native `torch.Generator` / `torch.randn` stream seeded from the same member-hour pair. These RNG streams are not bit-identical across frameworks, so individual stochastic members will not match pointwise unless TF-dumped noise is replayed (available in validate.py).

## Performance Snapshot

Same case, member `0`, batch size `1`, no nudging, no GRIB2, f06 GFS forcing:

- TensorFlow steady-state hours 2-6: average `57.4 s/hour`
- PyTorch eager + channels-last hours 2-6: average `29.8 s/hour` (`~1.9x` faster than TF)
- PyTorch `torch.compile` hours 2-6: average `14.7 s/hour` (`~3.9x` faster than TF, `~2.0x` faster than eager PyTorch)

Hours 2-6 are used for steady-state comparison to avoid first-hour XLA / Inductor warmup.

## Test Plan

- `python -m src_torch.convert` converts the Keras export with exact key/shape coverage.
- `python -m src_torch.cli validate --dump <TF_F01_DUMP>` passes thresholds.
- Generate f06 GFS forcing with `src/get_bcs.py` + `src/make_bcs.py`.
- Run `python -m src_torch.cli validate --rollout-dump <TF_DUMP_DIR>` for f00/f01/f06 parity.
- Run `python -m src_torch.cli forecast ...` to verify NetCDF output.
